### PR TITLE
feat: Add support for domain user accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,20 @@ $ export TSS_PASSWORD="Passw0rd."
 $ export TSS_SERVER_URL="https://localhost/SecretServer"
 $ terraform plan
 ```
+
+## Domain user accounts
+
+Domain users, such as Active Directory accounts, can be used by supplying the `tss_domain` parameter. E.G.
+
+```hcl
+tss_username   = "my_app_user"
+tss_password   = "Passw0rd."
+tss_server_url = "https://example/SecretServer"
+tss_domain     = "mycompany.com"
+```
+
+Alternatively, the domain can be provided with an environment variable:
+
+```sh
+$ export TSS_DOMAIN="mycompany.com"
+```

--- a/delinea/provider.go
+++ b/delinea/provider.go
@@ -11,6 +11,7 @@ func providerConfig(d *schema.ResourceData) (interface{}, error) {
 		Credentials: server.UserCredential{
 			Username: d.Get("username").(string),
 			Password: d.Get("password").(string),
+			Domain:   d.Get("domain").(string),
 		},
 	}, nil
 }
@@ -39,6 +40,12 @@ func Provider() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("TSS_PASSWORD", nil),
 				Description: "The password of the Secret Server User",
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TSS_DOMAIN", nil),
+				Description: "Domain of the Server Server user",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
This allows domain accounts (Active Directory, etc) to be used with the provider. Resolves #42 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] You have read the contributing guide
There is no contributing guide in this repository, should this requirement be ignored?
- [ ] Tests for the changes have been added
No tests are present in this repository, should this requirement be ignored?
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

_Please describe the current behavior that you are modifying, and link its a relevant issue_

Issue Number: _Add the issue number this PR address here._

## What is the new behavior?

- Support for domain accounts has been added

## Does this introduce a breaking change?

- [ ] Yes
- [x] No