### PR TITLE
Added support to generate SSH keys and passphrase

### DIFF
--- a/vars/secrets/secret_ssh.tfvars
+++ b/vars/secrets/secret_ssh.tfvars
@@ -1,6 +1,6 @@
-tss_username   = "admin"
-tss_password   = "Cybage@123"
-tss_server_url = "https://scimtest.secretservercloud.com"
+tss_username   = "username"
+tss_password   = "password"
+tss_server_url = "https://test.secretservercloud.com"
 tss_secret_name = "Sagar 2 SSH"
 tss_secret_siteid = 1
 tss_secret_folderid = 1530

--- a/vars/secrets/secret_ssh.tfvars
+++ b/vars/secrets/secret_ssh.tfvars
@@ -1,9 +1,9 @@
 tss_username   = "username"
 tss_password   = "password"
 tss_server_url = "https://test.secretservercloud.com"
-tss_secret_name = "Sagar 2 SSH"
+tss_secret_name = "Test SSH"
 tss_secret_siteid = 1
-tss_secret_folderid = 1530
+tss_secret_folderid = -1
 tss_secret_templateid = 6026
 fields = [
   {

--- a/vars/secrets/secret_ssh.tfvars
+++ b/vars/secrets/secret_ssh.tfvars
@@ -1,0 +1,29 @@
+tss_username   = "admin"
+tss_password   = "Cybage@123"
+tss_server_url = "https://scimtest.secretservercloud.com"
+tss_secret_name = "Sagar 2 SSH"
+tss_secret_siteid = 1
+tss_secret_folderid = 1530
+tss_secret_templateid = 6026
+fields = [
+  {
+    fieldname   = "Public Key"
+    itemvalue = null
+  },
+  {
+    fieldname   = "Private Key"
+    itemvalue = null
+  },
+  {
+    fieldname   = "Private Key Passphrase"
+    itemvalue = null
+  },
+  {
+    fieldname   = "Notes"
+    itemvalue = null
+  }
+]
+
+# SSH Key Generation Settings
+generate_passphrase = true
+generate_ssh_keys   = true


### PR DESCRIPTION
This update adds support for using the existing sshkeyargs flags when creating secrets in Secret Server:

generatesshkeys – Now can be passed to generate SSH keys during secret creation.

generatepassphrase – Now can be passed to generate a passphrase during secret creation.

With this change, users can provide values for these flags to automatically generate SSH keys and passphrases when creating secrets.