### PR TITLE
Added deletion resource to delete secret by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,40 @@ Above Create/Update Secret variables are for Windows Account secret template of 
 4. Based on template fields add/update field (with field name and item value) in fields array as above example. In above example there are four fields but in other template
  there might be more/less flieds. Accordingly, add/remove field entry from the fields array.
 
-Deactivate Secret:
+Delete Secret:
 
-The secret will be deactivated in the Secret Server when the `terraform destroy` command is executed.
+This functionality deactivates the secret in Delinea Secret Server.
+
+## Delete Secret by ID
+
+The `tss_secret_deletion` resource allows you to delete secrets by their ID, even if they are not managed by Terraform state.
+
+### Delete a Single Secret
+
+```hcl
+resource "tss_secret_deletion" "delete_secret" {
+  secret_id = 12345
+}
+```
+
+Apply this configuration to delete the secret with ID `12345`. After deletion, run `terraform destroy` to remove the resource from state before deleting another secret.
+
+### Delete Multiple Secrets
+
+```hcl
+resource "tss_secret_deletion" "delete_secrets" {
+  for_each = toset(["1001", "1002", "1003"])
+  secret_id = tonumber(each.key)
+}
+```
+
+This will delete all secrets listed in the set. Each deletion is tracked separately in state.
+
+**Best Practice:**
+- After deleting, run `terraform destroy` to clean up the state before deleting new secrets.
+- For batch deletions, use `for_each` or unique resource names.
+
+**Note:** The resource performs deletion during the `terraform apply` phase. The resource is tracked in state to prevent repeated deletion attempts. "Creating..." in logs means the deletion is being performed.
 
 ## Environment variables
 

--- a/delinea/provider.go
+++ b/delinea/provider.go
@@ -114,6 +114,9 @@ func (p *TSSProvider) DataSources(ctx context.Context) []func() datasource.DataS
 func (p *TSSProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		func() resource.Resource { return &TSSSecretResource{} },
+		func() resource.Resource {
+			return &TSSSecretDeletionResource{}
+		},
 		//For the DEBUG environment, uncomment this line to unit test whether the secret value is being fetched successfully.
 		//func() resource.Resource { return &PrintSecretResource{} },
 	}

--- a/delinea/resource_secret_deletion.go
+++ b/delinea/resource_secret_deletion.go
@@ -1,0 +1,175 @@
+package delinea
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DelineaXPM/tss-sdk-go/v2/server"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TSSSecretDeletionResource defines the resource implementation
+type TSSSecretDeletionResource struct {
+	clientConfig *server.Configuration // Store the provider configuration
+}
+
+// SecretDeletionResourceState defines the state structure for the deletion resource
+type SecretDeletionResourceState struct {
+	SecretID types.Int64  `tfsdk:"secret_id"`
+	ID       types.String `tfsdk:"id"`
+}
+
+// Metadata provides the resource type name
+func (r *TSSSecretDeletionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "tss_secret_deletion"
+}
+
+// Configure initializes the resource with the provider configuration
+func (r *TSSSecretDeletionResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*server.Configuration)
+	if !ok {
+		resp.Diagnostics.AddError("Configuration Error", "Failed to retrieve provider configuration")
+		return
+	}
+
+	// Store the provider configuration in the resource
+	r.clientConfig = config
+}
+
+// Schema defines the schema for the resource
+func (r *TSSSecretDeletionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "A resource to delete secrets by ID without requiring them to be in the Terraform state.",
+		Attributes: map[string]schema.Attribute{
+			"secret_id": schema.Int64Attribute{
+				Required:    true,
+				Description: "The ID of the secret to delete.",
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the resource. This is set to 'secret_<secret_id>' after deletion.",
+			},
+		},
+	}
+}
+
+// Create performs the secret deletion operation
+func (r *TSSSecretDeletionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan SecretDeletionResourceState
+
+	// Read the plan
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Ensure the client configuration is set
+	if r.clientConfig == nil {
+		resp.Diagnostics.AddError("Client Error", "The server client is not configured")
+		return
+	}
+
+	// Create the server client
+	client, err := server.New(*r.clientConfig)
+	if err != nil {
+		resp.Diagnostics.AddError("Configuration Error", fmt.Sprintf("Failed to create server client: %s", err))
+		return
+	}
+
+	secretID := int(plan.SecretID.ValueInt64())
+
+	// Check if the secret exists
+	_, err = client.Secret(secretID)
+	if err != nil {
+		resp.Diagnostics.AddError("Secret Not Found", fmt.Sprintf("The secret with ID %d does not exist: %s", secretID, err))
+		return
+	}
+
+	// Delete the secret
+	err = client.DeleteSecret(secretID)
+	if err != nil {
+		resp.Diagnostics.AddError("Secret Deletion Error", fmt.Sprintf("Failed to delete secret with ID %d: %s", secretID, err))
+		return
+	}
+
+	// Set the ID to a unique value based on the secret ID for Terraform state
+	plan.ID = types.StringValue(fmt.Sprintf("secret_%d", secretID))
+
+	// Set the state with the deleted secret information
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Read checks if the secret still exists
+func (r *TSSSecretDeletionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state SecretDeletionResourceState
+
+	// Read the state
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Ensure the client configuration is set
+	if r.clientConfig == nil {
+		resp.Diagnostics.AddError("Client Error", "The server client is not configured")
+		return
+	}
+
+	// Create the server client
+	client, err := server.New(*r.clientConfig)
+	if err != nil {
+		resp.Diagnostics.AddError("Configuration Error", fmt.Sprintf("Failed to create server client: %s", err))
+		return
+	}
+
+	secretID := int(state.SecretID.ValueInt64())
+
+	// Check if the secret still exists
+	_, err = client.Secret(secretID)
+	if err != nil {
+		// Secret doesn't exist, which is what we want
+		diags = resp.State.Set(ctx, state)
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Secret still exists, report as removed from state
+	resp.Diagnostics.AddWarning(
+		"Secret Still Exists",
+		fmt.Sprintf("Secret with ID %d still exists even though it was marked for deletion. This might indicate that the deletion failed or was reverted.", secretID),
+	)
+
+	// Still keep the state
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Update is a no-op since we can't update a deleted resource
+func (r *TSSSecretDeletionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan SecretDeletionResourceState
+
+	// Read the plan
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set the state with the plan
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Delete is a no-op because the secret was already deleted during Create
+func (r *TSSSecretDeletionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// The actual deletion was done in Create, so this is a no-op
+}

--- a/examples/secrets/secret_delete.tf
+++ b/examples/secrets/secret_delete.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_version = "1.12.1"
+  required_providers {
+    tss = {
+      source = "DelineaXPM/tss"
+      version = "3.0.0"
+    }
+  }
+}
+
+variable "tss_username" {
+  type = string
+}
+
+variable "tss_password" {
+  type = string
+}
+
+variable "tss_server_url" {
+  type = string
+}
+
+variable "tss_secret_id" {
+  type = string
+}
+
+provider "tss" {
+  username   = var.tss_username
+  password   = var.tss_password
+  server_url = var.tss_server_url
+}
+
+resource "tss_secret_deletion" "delete_secret" {
+  secret_id = var.tss_secret_id
+}

--- a/examples/secrets/secrets_delete.tf
+++ b/examples/secrets/secrets_delete.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = "1.12.1"
+  required_providers {
+    tss = {
+      source = "DelineaXPM/tss"
+      version = "3.0.0"
+    }
+  }
+}
+
+variable "tss_username" {
+  type = string
+}
+
+variable "tss_password" {
+  type = string
+}
+
+variable "tss_server_url" {
+  type = string
+}
+
+variable "tss_secret_ids" {
+  type = list(string)
+}
+
+provider "tss" {
+  username   = var.tss_username
+  password   = var.tss_password
+  server_url = var.tss_server_url
+}
+
+resource "tss_secret_deletion" "delete_secrets" {
+  for_each = toset(var.tss_secret_ids)
+  secret_id = tonumber(each.key)
+}

--- a/vars/secrets/secret_delete.tfvars
+++ b/vars/secrets/secret_delete.tfvars
@@ -1,0 +1,4 @@
+tss_username   = "username"
+tss_password   = "password"
+tss_server_url = "https://secretserver.com"
+tss_secret_id = 1

--- a/vars/secrets/secrets_delete.tfvars
+++ b/vars/secrets/secrets_delete.tfvars
@@ -1,0 +1,4 @@
+tss_username   = "username"
+tss_password   = "password"
+tss_server_url = "https://secretserver.com"
+tss_secret_ids = ["1", "2", "3"]


### PR DESCRIPTION
This PR introduces a new resource, tss_secret_deletion, which allows users to delete secrets from Delinea Secret Server by ID, even if those secrets are not managed by Terraform state.

**Features**
- Enables deletion of single or multiple secrets by specifying their IDs.
- Deletion is performed during terraform apply; the resource is tracked in state to prevent repeated deletion.
- Supports batch deletion using for_each.
