### PR TITLE
feat: add support for custom HTTP headers in provider configuration

### DIFF
--- a/delinea/header_transport.go
+++ b/delinea/header_transport.go
@@ -1,0 +1,34 @@
+package delinea
+
+import "net/http"
+
+// headerTransport wraps an http.RoundTripper to inject custom headers
+type headerTransport struct {
+	inner   http.RoundTripper
+	headers map[string]string
+}
+
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
+	return t.inner.RoundTrip(req)
+}
+
+// configureExtraHeaders wraps http.DefaultTransport to inject the given headers
+func configureExtraHeaders(headers map[string]string) {
+	if len(headers) == 0 {
+		return
+	}
+
+	// Avoid double-wrapping if Configure is called multiple times
+	current := http.DefaultTransport
+	if ht, ok := current.(*headerTransport); ok {
+		current = ht.inner
+	}
+
+	http.DefaultTransport = &headerTransport{
+		inner:   current,
+		headers: headers,
+	}
+}

--- a/delinea/header_transport_test.go
+++ b/delinea/header_transport_test.go
@@ -1,0 +1,48 @@
+package delinea
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHeaderTransport(t *testing.T) {
+	headers := map[string]string{
+		"X-Test-Header":  "test-value",
+		"CF-Access-Id":   "client-id",
+		"CF-Access-Auth": "client-secret",
+	}
+
+	// Mock server to check received headers
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range headers {
+			if r.Header.Get(k) != v {
+				t.Errorf("Expected header %s to be %s, got %s", k, v, r.Header.Get(k))
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create the transport
+	transport := &headerTransport{
+		inner:   http.DefaultTransport,
+		headers: headers,
+	}
+
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	// Execute request
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to execute request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status OK, got %v", resp.Status)
+	}
+}

--- a/delinea/provider.go
+++ b/delinea/provider.go
@@ -20,11 +20,12 @@ type TSSProvider struct{}
 
 // Define the provider schema model
 type TSSProviderModel struct {
-	ServerURL types.String `tfsdk:"server_url"`
-	Username  types.String `tfsdk:"username"`
-	Password  types.String `tfsdk:"password"`
-	Token     types.String `tfsdk:"token"`
-	Domain    types.String `tfsdk:"domain"`
+	ServerURL   types.String `tfsdk:"server_url"`
+	Username    types.String `tfsdk:"username"`
+	Password    types.String `tfsdk:"password"`
+	Token       types.String `tfsdk:"token"`
+	Domain      types.String `tfsdk:"domain"`
+	HTTPHeaders types.Map    `tfsdk:"http_headers"`
 }
 
 // Ensure the provider implements the ProviderWithEphemeralResources interface
@@ -60,6 +61,12 @@ func (p *TSSProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 			"domain": schema.StringAttribute{
 				Optional:    true,
 				Description: "Domain of the Secret Server user",
+			},
+			"http_headers": schema.MapAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
+				Description: "Additional HTTP headers to include in every API request",
 			},
 		},
 	}
@@ -111,6 +118,21 @@ func (p *TSSProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			Token:    config.Token.ValueString(),
 			Domain:   config.Domain.ValueString(),
 		},
+	}
+
+	// Configure extra HTTP headers if provided
+	if !config.HTTPHeaders.IsNull() && !config.HTTPHeaders.IsUnknown() {
+		headerElements := config.HTTPHeaders.Elements()
+		headers := make(map[string]string, len(headerElements))
+		for k, v := range headerElements {
+			if sv, ok := v.(types.String); ok {
+				headers[k] = sv.ValueString()
+			}
+		}
+		if len(headers) > 0 {
+			log.Printf("Configuring %d custom HTTP header(s)", len(headers))
+			configureExtraHeaders(headers)
+		}
 	}
 
 	// Pass the server configuration to resources and data sources

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,3 +68,19 @@ $ terraform plan
   - `password` (String) The password of the Secret Server User
 - Token authentication
   - `token` (String) An OAuth token to authenticate with the Secret Server
+
+### Optional
+
+- `http_headers` (Map of String, Sensitive) Additional HTTP headers to include in every API request. Useful when Secret Server is behind a reverse proxy that requires extra headers, e.g. service tokens.
+
+```terraform
+provider "tss" {
+  server_url = "https://secretserver.example.com/SecretServer"
+  username   = "my_app_user"
+  password   = "Passw0rd."
+
+  http_headers = {
+    "HeaderName" = "HeaderValue"
+  }
+}
+```


### PR DESCRIPTION
---
Add Support for Custom HTTP Headers
---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] You have read the contributing guide
- [x] Tests for the changes have been added
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

_Please describe the current behavior that you are modifying, and link its a relevant issue_
Currently, there is no way to add custom HTTP headers to API requests. This prevents the provider from working when the Secret Server is behind a proxy or WAF that requires specific headers for authentication or routing.

Issue Number: _Add the issue number this PR address here._

## What is the new behavior?

- Added a new `http_headers` attribute to the provider configuration to support custom HTTP headers.
- Included unit tests to verify headers are correctly attached to outgoing requests.
- Updated documentation with examples for common use cases like service tokens.
- Marked header values as sensitive to protect credentials in Terraform output.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

**If yes, please describe...**

## Other relevant information

_e.g. does this PR require another PR to be merged first?_