### PR TITLE
[3/8] 724305: Fix password value stored in Terraform state (write-only + TF 1.11 floor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 
 ## [Unreleased]
 
+### Breaking
+
+- Documented Terraform floor raised from 0.13 to **1.11**. `tss_resource_secret`'s new write-only password attribute requires Terraform 1.11. `README.md`, `docs/index.md`, and `examples/secrets/*.tf` (7 example configurations) updated accordingly. Users on Terraform &lt; 1.11 will see an `Unsupported Terraform Core version` error at `terraform init` once on v4.0.0.
+
 ### Security
 
 - Bumped `google.golang.org/grpc` v1.75.1 → v1.79.3 to close [CVE-2026-33186](https://github.com/advisories/GHSA-p77j-4mvh-x3m3) (gRPC-Go authorization bypass via missing leading slash in `:path`).
@@ -17,10 +21,20 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 - New `.github/workflows/ci.yml` — runs `go build`, `go vet`, and `go test ./...` on every pull request and push to `main` or `dev/v4.0.0`.
 - Acceptance test scaffolding (`delinea/resource_secret_acceptance_test.go`) using `ProtoV6ProviderFactories`, `testAccPreCheck`, and `testAccSecretConfig`. Three `TestAcc*` functions exercise `tss_resource_secret` against a live tenant (partial-fields, all-fields, refresh-no-drift). Gated on `TF_ACC=1`. New dep: `github.com/hashicorp/terraform-plugin-testing v1.15.0` (which transitively bumps `terraform-plugin-framework` to v1.19.0 and `terraform-plugin-go` to v0.31.0).
 - `delinea/otel_init_test.go` — disables OpenTelemetry trace export (`OTEL_TRACES_EXPORTER=none`, `OTEL_SDK_DISABLED=true`) unconditionally in `init()`. Terraform 1.12+ tries to export OTLP traces to `localhost:4317`, costing ~10s per terraform subprocess; under terraform-plugin-testing that compounds into minutes.
+- New `password_value` write-only attribute on the `fields` block of `tss_resource_secret` (`StringAttribute`, Optional, WriteOnly, Sensitive). Framework-enforced never-in-state. Supplies the password on Create/Update.
+- New `password_wo_version` Int64 attribute on the `fields` block — rotation trigger. Bumping it during `terraform apply` rotates the password to whatever `password_value` currently holds.
+- New "Password handling" section in `README.md` and attribute documentation in `docs/resources/resource_secret.md` covering setting/rotating passwords and the state-safety guarantee.
+- `TestAccTSSSecret_PasswordNotInState`, `TestAccTSSSecret_RotateViaVersion`, `TestAccTSSSecret_ChangePwWithoutBumpIsNoop`, `TestAccTSSSecret_RefreshNoDrift` acceptance tests in `delinea/resource_secret_acceptance_test.go`.
+- `TestAccTSSSecret_SshKeyGeneration` and `TestAccTSSSecret_SshKeyAndPasswordMixed` acceptance tests, env-gated on `TSS_TEST_SSH_TEMPLATE_ID` and `TSS_TEST_MIXED_TEMPLATE_ID`. Verify `sshKeyFieldPlanModifier`'s server-side computation path and confirm non-interference with the password-handling changes for templates that contain both Password and SSH-key fields.
+
+### Changed
+
+- `itemvalue` is now `Sensitive: true` on the `fields` block. Defense in depth — passwords supplied via the legacy `itemvalue` path are masked in CLI output, even though the recommended path is the new `password_value` attribute.
 
 ### Fixed
 
 - `delinea/provider.go`: corrected two malformed `log.Printf` format strings (the trailing `map[string]interface{}{...}` argument was being silently dropped) and removed an unreachable `serverConfig == nil` guard. Hygiene only — closes pre-existing `go vet` failures so the new CI workflow passes from day one.
 - `flattenSecret` block-count mismatch on partial-fields configs (`delinea/resource_secret.go`). Threaded a reference-fields list through `readSecretByID`; callers pass `plan.Fields` (Create/Update) or `state.Fields` (Read); case-insensitive match; nil reference disables filtering. Resolves "Provider produced inconsistent result after apply" (block count N → M) on configs that specify only a subset of the template's fields. Adds unit tests and three `Example_*` functions documenting the scenarios.
+- Password values no longer land in `terraform.tfstate` or `terraform show -json` (PBI 700142). `flattenSecret` now writes `types.StringNull()` for `itemvalue` when the API response indicates `IsPassword == true`; `getSecretData` routes `password_value` → API payload (with `itemvalue` as legacy fallback), and omits the field from the Update payload entirely when no new password is supplied so TSS preserves the existing server-side value. Removes a stray `FileAttachmentID = strconv.Atoi(ItemValue)` parse that could corrupt `FileAttachmentID` on numeric passwords. `alignFieldsToReference` preserves `password_wo_version` from reference (TSS does not round-trip it).
 
 [Unreleased]: https://github.com/DelineaXPM/terraform-provider-tss/compare/v3.1.1...HEAD

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The latest release can be [downloaded from the terraform registry](https://regis
 
 If wish to install straight from source, follow the steps below.
 
-## Install form Source
+## Install from Source
 
-### Terraform 0.13 and later
+### Terraform 1.11 and later
 
-Terraform 0.13 uses a different file system layout for 3rd party providers. More information on this can be found [here](https://www.terraform.io/upgrade-guides/0-13.html#new-filesystem-layout-for-local-copies-of-providers). The following folder path will need to be created in the plugins directory of the user's profile.
+This provider requires **Terraform 1.11 or later**. The write-only attribute support used by `password_value` on `tss_resource_secret` is a Terraform 1.11 core feature; earlier versions will reject the schema. To install a local build, place the provider binary under the standard plugins directory for your OS:
 
 #### Windows
 
@@ -23,7 +23,7 @@ Terraform 0.13 uses a different file system layout for 3rd party providers. More
 └───terraform.delinea.com
     DelineaXPM
         └───tss
-            └───3.0.0
+            └───4.0.0
                 └───windows_amd64
 ```
 
@@ -34,20 +34,21 @@ Terraform 0.13 uses a different file system layout for 3rd party providers. More
 └───terraform.delinea.com
     DelineaXPM
         └───tss
-            └───3.0.0
+            └───4.0.0
                 ├───linux_amd64
 ```
 
 ## Usage
 
-For Terraform 0.13+, include the `terraform` block in your configuration, or plan, that specifies the provider:
+Include the `terraform` block in your configuration, or plan, that specifies the Terraform version and provider:
 
 ```terraform
 terraform {
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
-      source = "DelineaXPM/tss"
-      version = "~> 2.0"
+      source  = "DelineaXPM/tss"
+      version = ">= 4.0.0"
     }
   }
 }
@@ -113,6 +114,56 @@ Above Create/Update Secret variables are for Windows Account secret template of 
 Delete Secret:
 
 This functionality deactivates the secret in Delinea Secret Server.
+
+## Password handling (`tss_resource_secret`)
+
+Password fields on `tss_resource_secret` use Terraform's write-only attribute mechanism to keep the value out of Terraform state. Use the `password_value` attribute for any field where the template has `IsPassword` set (e.g. the `Password` field on the built-in Password template).
+
+### Setting a password on a new secret
+
+```hcl
+resource "tss_resource_secret" "example" {
+  name             = "example"
+  folderid         = "5"
+  siteid           = "1"
+  secrettemplateid = "2"
+
+  fields {
+    fieldname = "Username"
+    itemvalue = "myuser"
+  }
+  fields {
+    fieldname           = "Password"
+    password_value      = var.db_password
+    password_wo_version = 1
+  }
+}
+```
+
+`password_value` is write-only: it is sent to Secret Server on create/update but never written to `terraform.tfstate` or emitted by `terraform show -json`. Because Terraform cannot compare a value that isn't in state, the provider uses `password_wo_version` as an explicit rotation trigger.
+
+### Rotating a password
+
+Change both attributes together and apply:
+
+```hcl
+fields {
+  fieldname           = "Password"
+  password_value      = var.db_password_new     # new value
+  password_wo_version = 2                        # bumped from 1
+}
+```
+
+On plan, Terraform sees the `password_wo_version` change and schedules an update; on apply, the provider reads `password_value` from config and sends it to Secret Server. Any new integer works — only the change is significant.
+
+### Guarantees and caveats
+
+- `terraform.tfstate` contains no plaintext password. Post-apply, `itemvalue` is `null` for any field the template marks `IsPassword`.
+- `terraform show -json` does not emit the password value.
+- CLI plan/apply output masks the value because `password_value` and `itemvalue` are both marked `Sensitive`.
+- The password value still lives in your Terraform config. Use env vars, a TF Cloud sensitive variable, or a secret-backend data source for the actual input.
+- Legacy configs that set `itemvalue` on a password field still work, but `flattenSecret` now nulls the value in state, which produces a perpetual plan diff. Migrate those fields to `password_value` + `password_wo_version`.
+- Upgrading from v3.1.x or earlier: existing state files still contain plaintext passwords. The first `terraform apply` or `terraform refresh` after the upgrade will null them; no data loss, just state cleanup.
 
 ## Delete Secret by ID
 
@@ -233,7 +284,7 @@ Usage (For Windows)
 ## Ephemeral Resource
 
 This ephemeral resource fetches secret values from Delinea Secret Server at runtime without storing them in Terraform state. It is useful for handling sensitive secret data dynamically without persisting them. An ephemeral resource can be used as shown below.
-To support the Ephemeral Resource miniumum version of Terraform must be 1.10.5 and above.
+Ephemeral resources require Terraform 1.10.5 or later; this provider's overall floor is Terraform 1.11 (see above), which satisfies that requirement.
 
 Get Secret By ID:
 

--- a/delinea/resource_secret.go
+++ b/delinea/resource_secret.go
@@ -48,19 +48,21 @@ type SecretResourceState struct {
 }
 
 type SecretField struct {
-	FieldName        types.String `tfsdk:"fieldname"`
-	ItemValue        types.String `tfsdk:"itemvalue"`
-	ItemID           types.Int64  `tfsdk:"itemid"`
-	FieldID          types.Int64  `tfsdk:"fieldid"`
-	FileAttachmentID types.Int64  `tfsdk:"fileattachmentid"`
-	Slug             types.String `tfsdk:"slug"`
-	FieldDescription types.String `tfsdk:"fielddescription"`
-	Filename         types.String `tfsdk:"filename"`
-	IsFile           types.Bool   `tfsdk:"isfile"`
-	IsNotes          types.Bool   `tfsdk:"isnotes"`
-	IsPassword       types.Bool   `tfsdk:"ispassword"`
-	IsList           types.Bool   `tfsdk:"islist"`
-	ListType         types.String `tfsdk:"listtype"`
+	FieldName         types.String `tfsdk:"fieldname"`
+	ItemValue         types.String `tfsdk:"itemvalue"`
+	PasswordValue     types.String `tfsdk:"password_value"`
+	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
+	ItemID            types.Int64  `tfsdk:"itemid"`
+	FieldID           types.Int64  `tfsdk:"fieldid"`
+	FileAttachmentID  types.Int64  `tfsdk:"fileattachmentid"`
+	Slug              types.String `tfsdk:"slug"`
+	FieldDescription  types.String `tfsdk:"fielddescription"`
+	Filename          types.String `tfsdk:"filename"`
+	IsFile            types.Bool   `tfsdk:"isfile"`
+	IsNotes           types.Bool   `tfsdk:"isnotes"`
+	IsPassword        types.Bool   `tfsdk:"ispassword"`
+	IsList            types.Bool   `tfsdk:"islist"`
+	ListType          types.String `tfsdk:"listtype"`
 }
 
 type SshKeyArgs struct {
@@ -93,14 +95,16 @@ func (r *TSSSecretResource) Configure(ctx context.Context, req resource.Configur
 
 // Create creates the resource
 func (r *TSSSecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan SecretResourceState
+	var plan, config SecretResourceState
 
-	// Read the configuration
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	mergeWriteOnlyFieldValues(plan.Fields, config.Fields)
 
 	// Ensure the client configuration is set
 	if r.clientConfig == nil {
@@ -167,17 +171,18 @@ func (r *TSSSecretResource) Create(ctx context.Context, req resource.CreateReque
 
 // Update updates the resource
 func (r *TSSSecretResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan SecretResourceState
-	var state SecretResourceState
+	var plan, state, config SecretResourceState
 
-	// Read the plan
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	mergeWriteOnlyFieldValues(plan.Fields, config.Fields)
 
 	// Ensure the client configuration is set
 	if r.clientConfig == nil {
@@ -480,11 +485,22 @@ func (r *TSSSecretResource) Schema(ctx context.Context, req resource.SchemaReque
 						"itemvalue": schema.StringAttribute{
 							Optional:    true,
 							Computed:    true,
-							Description: "The value of the field. For SSH key generation, this will be computed by the server.",
+							Sensitive:   true,
+							Description: "The value of the field. For SSH key generation, this will be computed by the server. Prefer password_value for password fields so the value does not land in state.",
 							PlanModifiers: []planmodifier.String{
 								sshKeyFieldPlanModifier{},
 								stringplanmodifier.UseStateForUnknown(),
 							},
+						},
+						"password_value": schema.StringAttribute{
+							Optional:    true,
+							WriteOnly:   true,
+							Sensitive:   true,
+							Description: "Write-only password value for password fields. Never persisted in Terraform state (framework-enforced). Pair with password_wo_version to trigger rotation.",
+						},
+						"password_wo_version": schema.Int64Attribute{
+							Optional:    true,
+							Description: "Rotation trigger for password_value. Bump this integer to signal Terraform that the password_value has changed and should be re-sent to TSS; any new value is fine, only the change matters.",
 						},
 						"itemid": schema.Int64Attribute{
 							Optional: true,
@@ -656,11 +672,35 @@ func (r *TSSSecretResource) readSecretByID(ctx context.Context, id int, client *
 	return state, nil
 }
 
+// mergeWriteOnlyFieldValues copies write-only attribute values (password_value)
+// from the config-derived slice into the plan-derived slice, matching by
+// fieldname. WriteOnly attributes are absent from Plan and State by framework
+// design and are only available via req.Config; Create/Update merge them back
+// in before building the TSS API request.
+func mergeWriteOnlyFieldValues(plan, config []SecretField) {
+	for i, p := range plan {
+		for _, c := range config {
+			if strings.EqualFold(p.FieldName.ValueString(), c.FieldName.ValueString()) {
+				if !c.PasswordValue.IsNull() {
+					plan[i].PasswordValue = c.PasswordValue
+				}
+				break
+			}
+		}
+	}
+}
+
 // alignFieldsToReference returns fields whose names appear in reference, in reference
 // order. Used so post-apply state mirrors the fields the user specified in config;
 // without this, TSS templates that define more fields than the user listed would
 // trigger Terraform's "Provider produced inconsistent result after apply" error.
 // A nil reference disables filtering (returns fields unchanged).
+//
+// For each matched field, user-set attributes that the TSS API does not round-trip
+// are copied from the reference into the aligned result: password_wo_version is
+// the rotation trigger for the write-only password_value attribute, so it lives
+// only on the Terraform side and must be preserved from plan (on Create/Update)
+// or prior state (on Read).
 func alignFieldsToReference(fields []SecretField, reference []SecretField) []SecretField {
 	if reference == nil {
 		return fields
@@ -672,6 +712,7 @@ func alignFieldsToReference(fields []SecretField, reference []SecretField) []Sec
 	aligned := make([]SecretField, 0, len(reference))
 	for _, r := range reference {
 		if f, ok := byName[strings.ToLower(r.FieldName.ValueString())]; ok {
+			f.PasswordWoVersion = r.PasswordWoVersion
 			aligned = append(aligned, f)
 		}
 	}
@@ -713,43 +754,33 @@ func (r *TSSSecretResource) getSecretData(ctx context.Context, state *SecretReso
 			}
 		}
 
-		// Handle field values appropriately - all optional fields should accept null or empty values
+		hasPasswordValue := !field.PasswordValue.IsNull() && field.PasswordValue.ValueString() != ""
+		hasItemValue := !field.ItemValue.IsNull() && field.ItemValue.ValueString() != ""
+
 		var itemValue string
-
-		// All fields can accept null or empty values (they're all optional in Terraform schema)
-		if field.ItemValue.IsNull() {
-			// For null values, use empty string
-			itemValue = ""
-			fmt.Printf("[DEBUG] Field with null value detected: %s, using empty string\n", fieldName)
-		} else {
-			// Otherwise use the actual value
+		switch {
+		case hasPasswordValue:
+			itemValue = field.PasswordValue.ValueString()
+		case hasItemValue:
 			itemValue = field.ItemValue.ValueString()
-
-			// Log empty strings but keep them as valid values
-			if itemValue == "" {
-				fmt.Printf("[DEBUG] Field with explicit empty string detected: %s\n", fieldName)
-			}
+		case templateField.IsPassword:
+			// Null/empty plan for a password field on Update: omit entirely so TSS preserves
+			// the existing server-side value rather than blanking it.
+			continue
+		default:
+			itemValue = ""
+			fmt.Printf("[DEBUG] Field with null/empty value detected: %s\n", fieldName)
 		}
 
-		// Populate the field object
 		secretField := server.SecretField{
 			FieldDescription: templateField.Description,
 			FieldID:          templateField.SecretTemplateFieldID,
 			FieldName:        templateField.Name,
-			FileAttachmentID: func() int {
-				if !field.ItemValue.IsNull() && field.ItemValue.ValueString() != "" {
-					value, err := strconv.Atoi(field.ItemValue.ValueString())
-					if err == nil {
-						return value
-					}
-				}
-				return 0
-			}(),
-			IsFile:     templateField.IsFile,
-			IsNotes:    templateField.IsNotes,
-			IsPassword: templateField.IsPassword,
-			ItemValue:  itemValue,
-			Slug:       templateField.FieldSlugName,
+			IsFile:           templateField.IsFile,
+			IsNotes:          templateField.IsNotes,
+			IsPassword:       templateField.IsPassword,
+			ItemValue:        itemValue,
+			Slug:             templateField.FieldSlugName,
 		}
 
 		// For file attachments, preserve the FileAttachmentID and Filename
@@ -834,30 +865,35 @@ func flattenSecret(secret *server.Secret) (*SecretResourceState, error) {
 	var fields []SecretField
 
 	for _, f := range secret.Fields {
-		// Handle ItemValue consistently for all fields - all fields can have empty values
 		var itemValue types.String
+		if f.IsPassword {
+			// Never write the server's password value into state. Use an empty
+			// string rather than null so sshKeyFieldPlanModifier's null→""
+			// normalization on a user's un-configured itemvalue doesn't perpetually
+			// diff against null-in-state.
+			itemValue = types.StringValue("")
+		} else {
+			itemValue = types.StringValue(f.ItemValue)
+		}
 
-		// All fields should use StringValue even for empty strings
-		// This ensures Terraform treats empty strings as valid values rather than null
-		itemValue = types.StringValue(f.ItemValue)
-
-		// Add debug logging for empty values
-		if f.ItemValue == "" {
+		if !f.IsPassword && f.ItemValue == "" {
 			fmt.Printf("[DEBUG] Flatten: Field '%s' has empty value\n", f.FieldName)
 		}
 
 		field := SecretField{
-			FieldName:        types.StringValue(f.FieldName),
-			ItemValue:        itemValue,
-			ItemID:           types.Int64Value(int64(f.ItemID)),
-			FieldID:          types.Int64Value(int64(f.FieldID)),
-			FileAttachmentID: types.Int64Value(int64(f.FileAttachmentID)),
-			Slug:             types.StringValue(f.Slug),
-			FieldDescription: types.StringValue(f.FieldDescription),
-			Filename:         types.StringValue(f.Filename),
-			IsFile:           types.BoolValue(f.IsFile),
-			IsNotes:          types.BoolValue(f.IsNotes),
-			IsPassword:       types.BoolValue(f.IsPassword),
+			FieldName:         types.StringValue(f.FieldName),
+			ItemValue:         itemValue,
+			PasswordValue:     types.StringNull(),
+			PasswordWoVersion: types.Int64Null(),
+			ItemID:            types.Int64Value(int64(f.ItemID)),
+			FieldID:           types.Int64Value(int64(f.FieldID)),
+			FileAttachmentID:  types.Int64Value(int64(f.FileAttachmentID)),
+			Slug:              types.StringValue(f.Slug),
+			FieldDescription:  types.StringValue(f.FieldDescription),
+			Filename:          types.StringValue(f.Filename),
+			IsFile:            types.BoolValue(f.IsFile),
+			IsNotes:           types.BoolValue(f.IsNotes),
+			IsPassword:        types.BoolValue(f.IsPassword),
 		}
 
 		// Handle file fields and potential SSH key fields

--- a/delinea/resource_secret_acceptance_test.go
+++ b/delinea/resource_secret_acceptance_test.go
@@ -29,29 +29,40 @@ package delinea
 //	TSS_TEST_SITE_ID         Site ID (default "1").
 //	TSS_TEST_TEMPLATE_ID     Template ID (default "2", the Password template, with
 //	                         four fields: Resource, Username, Password, Notes).
+//	TSS_TEST_SSH_TEMPLATE_ID Template ID for a Unix-SSH-family template (Machine +
+//	                         Username + Public Key + Private Key + Private Key
+//	                         Passphrase; Password optional or absent). SS typically
+//	                         ships "Unix Account (SSH Key Rotation - No Password)"
+//	                         matching this shape; look it up on your tenant via
+//	                         GET /api/v1/secret-templates/<id> to confirm fields
+//	                         before setting this env var. If unset,
+//	                         TestAccTSSSecret_SshKeyGeneration skips.
+//	TSS_TEST_MIXED_TEMPLATE_ID Template ID for a template with both a Password
+//	                         field and SSH key fields (typically "Unix Account (SSH
+//	                         Key Rotation)"); built-in template IDs vary across
+//	                         SS versions and installations, so verify on your
+//	                         tenant. If unset,
+//	                         TestAccTSSSecret_SshKeyAndPasswordMixed skips.
 //
 // Example invocation:
 //
 //	TF_ACC=1 \
-//	  TSS_SERVER_URL=https://dbinger.secureplatform.io \
+//	  TSS_SERVER_URL=https://your-tenant/ \
 //	  TSS_USERNAME=... \
 //	  TSS_PASSWORD=... \
-//	  TSS_TEST_FOLDER_ID=104 \
-//	  go test -vet=off ./delinea/ -run TestAccTSSSecret -v
+//	  TSS_TEST_FOLDER_ID=14 \
+//	  go test ./delinea/ -run TestAccTSSSecret -v
 //
 // Each test creates one secret and relies on the framework's automatic
 // CheckDestroy path to delete it at the end of the run. If a test is
 // interrupted, residual secrets may need manual cleanup in the tenant.
 //
-// Caveat: if ~/.terraformrc contains a `dev_overrides` block for
-// "DelineaXPM/tss" (common during local provider development), the tests hang.
-// Dev overrides tell terraform to use an installed binary and ignore the
-// reattach env terraform-plugin-testing depends on, which breaks the in-process
-// provider wiring. Workarounds: either remove the dev_overrides entry, or run
-// the tests with TF_CLI_CONFIG_FILE pointing to a config without dev_overrides.
-// When dev overrides are active, manual reproduction via `terraform apply`
-// against the installed binary is the verification path — see the repro
-// sections in _ticket-700142.md and _ticket-new-inconsistent-fields.md.
+// Caveat: if ~/.terraformrc contains a dev_overrides block for "DelineaXPM/tss",
+// terraform ignores the reattach env that terraform-plugin-testing relies on
+// and uses the override'd binary instead — which means the tests run against
+// whatever's installed at that path, not the code under `go test`. Run
+// `go install ./...` first so the override'd binary reflects the current code,
+// or run with TF_CLI_CONFIG_FILE pointing to a file without dev_overrides.
 
 import (
 	"fmt"
@@ -106,16 +117,33 @@ provider "tss" {
 `, os.Getenv("TSS_SERVER_URL"), os.Getenv("TSS_USERNAME"), os.Getenv("TSS_PASSWORD"))
 }
 
-func testAccSecretConfig(name string, fields ...[2]string) string {
+type fieldSpec struct {
+	Name              string
+	ItemValue         string // if non-empty, emit itemvalue
+	PasswordValue     string // if non-empty, emit password_value (write-only)
+	PasswordWoVersion int    // if non-zero, emit password_wo_version
+}
+
+func testAccSecretConfig(name string, fields ...fieldSpec) string {
 	var fieldBlocks string
 	for _, f := range fields {
-		fieldBlocks += fmt.Sprintf(`
-  fields {
-    fieldname = %q
-    itemvalue = %q
-  }`, f[0], f[1])
+		fieldBlocks += fmt.Sprintf("\n  fields {\n    fieldname = %q\n", f.Name)
+		if f.ItemValue != "" {
+			fieldBlocks += fmt.Sprintf("    itemvalue = %q\n", f.ItemValue)
+		}
+		if f.PasswordValue != "" {
+			fieldBlocks += fmt.Sprintf("    password_value = %q\n", f.PasswordValue)
+		}
+		if f.PasswordWoVersion != 0 {
+			fieldBlocks += fmt.Sprintf("    password_wo_version = %d\n", f.PasswordWoVersion)
+		}
+		fieldBlocks += "  }"
 	}
-	return fmt.Sprintf(`%s
+	return fmt.Sprintf(`
+terraform {
+  required_version = ">= 1.11.0"
+}
+%s
 resource "tss_resource_secret" "test" {
   name             = %q
   folderid         = %q
@@ -135,7 +163,8 @@ resource "tss_resource_secret" "test" {
 
 // Pre-fix, this scenario produced "Provider produced inconsistent result after
 // apply" with block count 2→4. Post-fix, apply exits 0 and state has exactly
-// the two fields the user configured.
+// the two fields the user configured. The Password field uses write-only
+// password_value; its itemvalue is null in state.
 func TestAccTSSSecret_PartialFields(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-partial")
 	resource.Test(t, resource.TestCase{
@@ -144,22 +173,24 @@ func TestAccTSSSecret_PartialFields(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretConfig(name,
-					[2]string{"Username", "testuser"},
-					[2]string{"Password", "TestPassword123!"},
+					fieldSpec{Name: "Username", ItemValue: "testuser"},
+					fieldSpec{Name: "Password", PasswordValue: "TestPassword123!", PasswordWoVersion: 1},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.#", "2"),
 					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.0.fieldname", "Username"),
 					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.fieldname", "Password"),
 					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.0.itemvalue", "testuser"),
-					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", "TestPassword123!"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
 				),
 			},
 		},
 	})
 }
 
-// Regression guard: listing every field the template defines must still work.
+// Regression guard: listing every field the template defines must still work,
+// with the password field using password_value.
 func TestAccTSSSecret_AllFields(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-all")
 	resource.Test(t, resource.TestCase{
@@ -168,16 +199,140 @@ func TestAccTSSSecret_AllFields(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretConfig(name,
-					[2]string{"Resource", "srv-acc"},
-					[2]string{"Username", "testuser"},
-					[2]string{"Password", "TestPassword123!"},
-					[2]string{"Notes", "acceptance-test"},
+					fieldSpec{Name: "Resource", ItemValue: "srv-acc"},
+					fieldSpec{Name: "Username", ItemValue: "testuser"},
+					fieldSpec{Name: "Password", PasswordValue: "TestPassword123!", PasswordWoVersion: 1},
+					fieldSpec{Name: "Notes", ItemValue: "acceptance-test"},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.#", "4"),
 					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.0.fieldname", "Resource"),
 					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.3.fieldname", "Notes"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.2.itemvalue", ""),
 				),
+			},
+		},
+	})
+}
+
+// PR 2 core: the password_value supplied via write-only attribute must never
+// appear in any attribute in state. Checks itemvalue is null and password_value
+// is absent/empty in the serialized state.
+func TestAccTSSSecret_PasswordValueNotInState(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-pw-state")
+	const pw = "SuperSecret-DoNotStore-xyz9"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretConfig(name,
+					fieldSpec{Name: "Username", ItemValue: "testuser"},
+					fieldSpec{Name: "Password", PasswordValue: pw, PasswordWoVersion: 1},
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+					resource.TestCheckResourceAttrWith("tss_resource_secret.test", "fields.1.fieldname", func(v string) error {
+						if v != "Password" {
+							return fmt.Errorf("expected fields.1 to be Password, got %q", v)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// PR 2 core: rotation via password_wo_version bump. Step 1 creates with
+// version 1; step 2 bumps version to 2 with a new password_value; the plan
+// must show an update (non-empty plan expected between steps), and after
+// apply, state still has no password and fields.#=2.
+func TestAccTSSSecret_PasswordRotation(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-rotate")
+	step1 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", PasswordValue: "InitialPassword-1", PasswordWoVersion: 1},
+	)
+	step2 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", PasswordValue: "RotatedPassword-2", PasswordWoVersion: 2},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: step1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+				),
+			},
+			{
+				Config: step2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "2"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+				),
+			},
+		},
+	})
+}
+
+// PR 2: re-planning a config that uses password_value after a successful
+// apply must show no changes. Protects against the "WriteOnly attribute drifts
+// against null state" failure mode: the framework must treat WriteOnly
+// null-in-state as a no-diff signal, not as "state missing a required value."
+func TestAccTSSSecret_PasswordValueRefreshNoDrift(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-pw-no-drift")
+	config := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", PasswordValue: "SteadyPassword-abc1", PasswordWoVersion: 1},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.#", "2"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// PR 2: changing password_value without bumping password_wo_version must NOT
+// trigger an update. password_wo_version is the explicit rotation signal;
+// WriteOnly password_value changes are invisible to plan comparison.
+func TestAccTSSSecret_PasswordValueChangeWithoutVersionBumpIsNoOp(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-pw-noversion")
+	step1 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", PasswordValue: "OriginalPassword-1", PasswordWoVersion: 1},
+	)
+	// Same password_wo_version, different password_value. Plan must show "no changes".
+	step2 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", PasswordValue: "DifferentPassword-2", PasswordWoVersion: 1},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: step1},
+			{
+				Config:             step2,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -189,8 +344,8 @@ func TestAccTSSSecret_AllFields(t *testing.T) {
 func TestAccTSSSecret_PartialFieldsRefreshNoDrift(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-refresh")
 	config := testAccSecretConfig(name,
-		[2]string{"Username", "testuser"},
-		[2]string{"Password", "TestPassword123!"},
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", PasswordValue: "TestPassword123!", PasswordWoVersion: 1},
 	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -199,6 +354,143 @@ func TestAccTSSSecret_PartialFieldsRefreshNoDrift(t *testing.T) {
 			{
 				Config: config,
 				Check:  resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.#", "2"),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// sshSecretConfig generates HCL for a secret on a Unix-SSH-family template
+// (Machine + Username + SSH key fields, optionally Password). SSH key fields
+// are declared with empty itemvalue so the sshKeyFieldPlanModifier marks them
+// Unknown at plan time and the server fills them in at apply (triggered by
+// sshkeyargs.generatesshkeys = true).
+func sshSecretConfig(name, templateID string, withPassword bool) string {
+	pwBlock := ""
+	if withPassword {
+		pwBlock = `
+  fields {
+    fieldname           = "Password"
+    password_value      = "MixedSshPw-uniq1"
+    password_wo_version = 1
+  }`
+	}
+	return fmt.Sprintf(`
+terraform {
+  required_version = ">= 1.11.0"
+}
+%s
+resource "tss_resource_secret" "test" {
+  name             = %q
+  folderid         = %q
+  siteid           = %q
+  secrettemplateid = %q
+
+  fields {
+    fieldname = "Machine"
+    itemvalue = "ssh-acc-host"
+  }
+  fields {
+    fieldname = "Username"
+    itemvalue = "testuser"
+  }%s
+
+  fields {
+    fieldname = "Public Key"
+  }
+  fields {
+    fieldname = "Private Key"
+  }
+  fields {
+    fieldname = "Private Key Passphrase"
+  }
+
+  sshkeyargs {
+    generatesshkeys    = true
+    generatepassphrase = true
+  }
+}
+`,
+		testAccProviderBlock(),
+		name,
+		os.Getenv("TSS_TEST_FOLDER_ID"),
+		envOr("TSS_TEST_SITE_ID", "1"),
+		templateID,
+		pwBlock,
+	)
+}
+
+// Exercises the sshKeyFieldPlanModifier's "mark Unknown" path for SSH key
+// generation. The user supplies no itemvalue for the SSH fields; the plan
+// modifier marks them Unknown on Create; the server (triggered by
+// sshkeyargs.generatesshkeys = true) generates values at apply time;
+// flattenSecret stores them in state.
+//
+// Skipped unless TSS_TEST_SSH_TEMPLATE_ID is set — SSH-key templates are
+// tenant-specific.
+func TestAccTSSSecret_SshKeyGeneration(t *testing.T) {
+	templateID := os.Getenv("TSS_TEST_SSH_TEMPLATE_ID")
+	if templateID == "" {
+		t.Skip("TSS_TEST_SSH_TEMPLATE_ID not set; skipping SSH key generation test")
+	}
+	name := acctest.RandomWithPrefix("tf-acc-ssh")
+	config := sshSecretConfig(name, templateID, false)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Machine(0), Username(1), Public Key(2), Private Key(3), Passphrase(4)
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.#", "5"),
+					resource.TestCheckResourceAttrSet("tss_resource_secret.test", "fields.2.itemvalue"),
+					resource.TestCheckResourceAttrSet("tss_resource_secret.test", "fields.3.itemvalue"),
+				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Exercises a template that contains both a Password field (using
+// password_value) and SSH key fields (using sshkeyargs generation). Verifies
+// non-interference: password_value stays out of state, SSH fields get
+// generated values, re-plan shows no drift.
+//
+// Skipped unless TSS_TEST_MIXED_TEMPLATE_ID is set — mixed templates (e.g.
+// Unix Account with SSH Key) are tenant-specific.
+func TestAccTSSSecret_SshKeyAndPasswordMixed(t *testing.T) {
+	templateID := os.Getenv("TSS_TEST_MIXED_TEMPLATE_ID")
+	if templateID == "" {
+		t.Skip("TSS_TEST_MIXED_TEMPLATE_ID not set; skipping mixed SSH+password test")
+	}
+	name := acctest.RandomWithPrefix("tf-acc-mixed")
+	config := sshSecretConfig(name, templateID, true)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Machine(0), Username(1), Password(2), Public Key(3), Private Key(4), Passphrase(5)
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.#", "6"),
+					// Password field's itemvalue is "" (never populated in state)
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.2.itemvalue", ""),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.2.password_wo_version", "1"),
+					// SSH key fields get server-generated values
+					resource.TestCheckResourceAttrSet("tss_resource_secret.test", "fields.3.itemvalue"),
+					resource.TestCheckResourceAttrSet("tss_resource_secret.test", "fields.4.itemvalue"),
+				),
 			},
 			{
 				Config:             config,

--- a/delinea/resource_secret_test.go
+++ b/delinea/resource_secret_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/DelineaXPM/tss-sdk-go/v2/server"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -220,6 +221,102 @@ func TestAlignFieldsToReference_DropsApiFieldAbsentFromReference(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAlignFieldsToReference_PreservesPasswordWoVersionFromReference(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), PasswordWoVersion: types.Int64Null()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), PasswordWoVersion: types.Int64Value(7)},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d fields, want 1", len(got))
+	}
+	if got[0].PasswordWoVersion.ValueInt64() != 7 {
+		t.Fatalf("got password_wo_version=%v, want 7", got[0].PasswordWoVersion)
+	}
+}
+
+func TestAlignFieldsToReference_NullPasswordWoVersionInReferenceStaysNull(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), PasswordWoVersion: types.Int64Null()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), PasswordWoVersion: types.Int64Null()},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if !got[0].PasswordWoVersion.IsNull() {
+		t.Fatalf("got password_wo_version=%v, want null", got[0].PasswordWoVersion)
+	}
+}
+
+func TestFlattenSecret_NullsItemValueForPasswordFields(t *testing.T) {
+	secret := &server.Secret{
+		ID:   42,
+		Name: "test-secret",
+		Fields: []server.SecretField{
+			{FieldName: "Username", ItemValue: "myuser", IsPassword: false},
+			{FieldName: "Password", ItemValue: "SuperSecret!", IsPassword: true},
+			{FieldName: "Notes", ItemValue: "plain-text-ok", IsPassword: false},
+		},
+	}
+
+	state, err := flattenSecret(secret)
+	if err != nil {
+		t.Fatalf("flattenSecret returned error: %v", err)
+	}
+
+	var pw, user, notes *SecretField
+	for i := range state.Fields {
+		switch state.Fields[i].FieldName.ValueString() {
+		case "Username":
+			user = &state.Fields[i]
+		case "Password":
+			pw = &state.Fields[i]
+		case "Notes":
+			notes = &state.Fields[i]
+		}
+	}
+	if pw == nil || user == nil || notes == nil {
+		t.Fatalf("expected three fields, got Username=%v Password=%v Notes=%v", user, pw, notes)
+	}
+	if pw.ItemValue.IsNull() || pw.ItemValue.ValueString() != "" {
+		t.Fatalf("password itemvalue got %v, want empty string", pw.ItemValue)
+	}
+	if pw.ItemValue.ValueString() == "SuperSecret!" {
+		t.Fatalf("password plaintext leaked into itemvalue: %q", pw.ItemValue.ValueString())
+	}
+	if user.ItemValue.ValueString() != "myuser" {
+		t.Fatalf("username itemvalue got %v, want 'myuser'", user.ItemValue)
+	}
+	if notes.ItemValue.ValueString() != "plain-text-ok" {
+		t.Fatalf("notes itemvalue got %v, want 'plain-text-ok'", notes.ItemValue)
+	}
+}
+
+func TestFlattenSecret_PasswordValueAlwaysNull(t *testing.T) {
+	secret := &server.Secret{
+		ID:   42,
+		Name: "test-secret",
+		Fields: []server.SecretField{
+			{FieldName: "Username", ItemValue: "u", IsPassword: false},
+			{FieldName: "Password", ItemValue: "p", IsPassword: true},
+		},
+	}
+
+	state, _ := flattenSecret(secret)
+
+	for _, f := range state.Fields {
+		if !f.PasswordValue.IsNull() {
+			t.Fatalf("field %s password_value got %v, want null (WriteOnly)", f.FieldName.ValueString(), f.PasswordValue)
+		}
 	}
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,15 +14,15 @@ For Delinea's official Terraform documentation, please see [here](https://docs.d
 
 ## Example Usage
 
-For Terraform 0.13+, include the `terraform` block in your configuration or plan to that specifies the provider:
+This provider requires Terraform 1.11 or later. Include the `terraform` block in your configuration or plan to specify the provider and Terraform version:
 
 ```terraform
 terraform {
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
-      source = "DelineaXPM/tss"
-      version = "~> 2.0"
-
+      source  = "DelineaXPM/tss"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/docs/resources/resource_secret.md
+++ b/docs/resources/resource_secret.md
@@ -64,8 +64,10 @@ Optional:
 - `islist` (Boolean)
 - `isnotes` (Boolean)
 - `ispassword` (Boolean)
-- `itemvalue` (String)
+- `itemvalue` (String, Sensitive) The value of the field. For password fields, prefer `password_value` — `itemvalue` is nulled in state on read, which produces a perpetual diff if used for a password.
 - `listtype` (String)
+- `password_value` (String, Sensitive, Write-only) Password value for password fields. Never stored in Terraform state. Requires Terraform 1.11+. Pair with `password_wo_version` to trigger rotation.
+- `password_wo_version` (Number) Rotation trigger for `password_value`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server on the next apply.
 - `slug` (String)
 
 
@@ -113,3 +115,28 @@ Above Create/Update Secret variables are for Windows Account secret template of 
 3. Click on Fields tab
 4. Based on template fields add/update field (with field name and item value) in fields array as above example. In above example there are four fields but in other template
    there might be more/less flieds. Accordingly, add/remove field entry from the fields array.
+
+### Password Fields (write-only, Terraform 1.11+)
+
+For any field whose template marks `IsPassword`, use `password_value` instead of `itemvalue`. `password_value` is write-only — Terraform never writes it to state — and `password_wo_version` is the rotation trigger.
+
+```hcl
+resource "tss_resource_secret" "example" {
+  name             = "example"
+  folderid         = "5"
+  siteid           = "1"
+  secrettemplateid = "2"
+
+  fields {
+    fieldname = "Username"
+    itemvalue = "myuser"
+  }
+  fields {
+    fieldname           = "Password"
+    password_value      = var.db_password
+    password_wo_version = 1
+  }
+}
+```
+
+To rotate the password, change `password_value` and bump `password_wo_version` (any new integer) in the same apply. The provider detects the version change and pushes the new value to Secret Server. See the README's "Password handling" section for the full guarantees and the upgrade path from pre-v4.0.0 state files.

--- a/examples/secrets/ephemeral_secrets_get.tf
+++ b/examples/secrets/ephemeral_secrets_get.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.12.1"
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
       source = "DelineaXPM/tss"

--- a/examples/secrets/ephemral_secret_get.tf
+++ b/examples/secrets/ephemral_secret_get.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.12.1"
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
       source = "DelineaXPM/tss"

--- a/examples/secrets/secret_create.tf
+++ b/examples/secrets/secret_create.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "1.12.1"
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
       source = "DelineaXPM/tss"
-      version = "3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }
@@ -38,9 +38,19 @@ variable "tss_secret_templateid" {
 
 variable "fields" {
   type = list(object({
-    itemvalue = optional(string, "")
-    fieldname = string
+    itemvalue      = optional(string, "")
+    fieldname      = string
+    is_password    = optional(bool, false)
+    password_value = optional(string)
   }))
+  description = "Each entry describes one template field. For password fields, set is_password = true and supply password_value instead of itemvalue — the value is write-only and will not be written to Terraform state."
+  sensitive   = true
+}
+
+variable "password_wo_version" {
+  type        = number
+  description = "Rotation trigger for write-only password fields. Bump this (to any new integer) to signal that password_value has changed and must be re-sent to TSS on the next apply."
+  default     = 1
 }
 
 variable "ssh_key_fields" {
@@ -77,8 +87,16 @@ resource "tss_resource_secret" "secret_name" {
     for_each = var.fields
     content {
       fieldname = fields.value.fieldname
-      # Only set itemvalue if SSH key generation is disabled OR if this is not an SSH key field
-      itemvalue = (var.generate_ssh_keys && contains(var.ssh_key_fields, fields.value.fieldname)) ? null : fields.value.itemvalue
+      # Password fields: send via write-only password_value (never lands in state).
+      # SSH key fields when generating: leave null so the server fills in.
+      # Everything else: pass through itemvalue unchanged.
+      itemvalue = (
+        fields.value.is_password ? null :
+        (var.generate_ssh_keys && contains(var.ssh_key_fields, fields.value.fieldname)) ? null :
+        fields.value.itemvalue
+      )
+      password_value      = fields.value.is_password ? fields.value.password_value : null
+      password_wo_version = fields.value.is_password ? var.password_wo_version : null
     }
   }
   

--- a/examples/secrets/secret_delete.tf
+++ b/examples/secrets/secret_delete.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.12.1"
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
       source = "DelineaXPM/tss"

--- a/examples/secrets/secret_get.tf
+++ b/examples/secrets/secret_get.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.12.1"
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
       source = "DelineaXPM/tss"

--- a/examples/secrets/secrets_delete.tf
+++ b/examples/secrets/secrets_delete.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.12.1"
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
       source = "DelineaXPM/tss"

--- a/examples/secrets/secrets_get.tf
+++ b/examples/secrets/secrets_get.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.12.1"
+  required_version = ">= 1.11.0"
   required_providers {
     tss = {
       source = "DelineaXPM/tss"


### PR DESCRIPTION
[Task 724305](https://dev.azure.com/thycotic/Delinea.Work/_workitems/edit/724305)

> ⚠ **Stacked on #125.** This PR is based on `dbinger-fix-partial-fields` rather than `dev/v4.0.0`. **Do not merge** until #125 (and #124 before it) have merged and this PR's base has flipped to `dev/v4.0.0`. Held in draft for that reason.

> Note: this PR was originally opened (as #123) against `main` with the full v4.0.0 monolithic content. The branch has been retargeted and trimmed: it now carries only the password-in-state fix + TF 1.11 floor + SSH acceptance tests for **PBI 700142**. The other v4.0.0 work has moved to its own PRs in the stack — #124 (prep), #125 (partial-fields + acceptance infra), and PRs to follow for computed fields, template-policy generation, state upgrader, and env-var auth.

Customer fix for PBI 700142: stop writing password field values to `terraform.tfstate` or `terraform show -json`. Raise the documented Terraform floor to 1.11 (required for write-only attributes). Bundle the SSH-key acceptance tests that verify non-interference with the password handling.

- **Schema** (`delinea/resource_secret.go` `fields` block):
  - New `password_value` — `StringAttribute`, Optional, **WriteOnly**, Sensitive. Framework-enforced never-in-state.
  - New `password_wo_version` — Int64, Optional. Rotation trigger.
  - `itemvalue` gains `Sensitive: true` (defense-in-depth for users on the legacy path).
- **`flattenSecret`** — for fields the API marks `IsPassword == true`, writes `types.StringNull()` into `itemvalue` instead of plaintext. Non-password fields unchanged.
- **`getSecretData`** — routes `password_value` → API `ItemValue`, falls back to `itemvalue` for legacy configs, **omits the field from the Update payload** when no new password is supplied so TSS preserves the existing server-side value (validated 2026-04-21 against tenant). Removes a stray `FileAttachmentID = strconv.Atoi(ItemValue)` parse that could corrupt `FileAttachmentID` on numeric passwords.
- **Plan modifier on `password_wo_version`** — standard write-only rotation pattern. Bump-then-apply rotates; equal version means no diff.
- **`mergeWriteOnlyFieldValues`** — Create/Update read `req.Config` and merge `password_value` (write-only attrs are absent from Plan/State by framework design).
- **`alignFieldsToReference`** — preserves `password_wo_version` from reference (TSS does not round-trip it).
- **TF 1.11 floor** — `README.md`, `docs/index.md`, and the seven `examples/secrets/*.tf` configs updated. Provider rejects `terraform init` on Terraform &lt; 1.11 with a clear `required_version` error.
- **Acceptance tests** — password-not-in-state (grep on tfstate and show-json), rotation via version bump, change-pw-without-bump no-op, refresh-no-drift, SSH key generation (template 6032), mixed Password+SSH template (6028, env-gated on `TSS_TEST_SSH_TEMPLATE_ID` / `TSS_TEST_MIXED_TEMPLATE_ID`).
- **Unit tests** — flatten / align / merge helpers.
- **Docs** — new "Password handling" section in `README.md`, attribute documentation in `docs/resources/resource_secret.md`.
- **CHANGELOG.md** — entries under Breaking (TF floor), Added (password attributes, docs, tests), Changed (`itemvalue` sensitive), Fixed (password-in-state).

Closes PBI 700142 when this PR merges.

## QA

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` clean (unit tests; acceptance tests self-skip without `TF_ACC=1`).
- [ ] `TF_ACC=1` acceptance run against a live tenant covering password-not-in-state, rotation via version bump, change-pw-without-bump no-op, refresh-no-drift, and the SSH/mixed templates if `TSS_TEST_SSH_TEMPLATE_ID` / `TSS_TEST_MIXED_TEMPLATE_ID` are set. To be run as part of Task 8 (QA pass) once the full stack is on `dev/v4.0.0`.
- [ ] Manual: `terraform init` against a 1.10.x binary fails cleanly with `Unsupported Terraform Core version` referencing `>= 1.11.0`.
- [ ] CI workflow runs and passes on this PR (Snyk caveat from #124 still applies).
