### PR TITLE
[4/8] 726495: Add template-policy password generation (gh #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 - New "Password handling" section in `README.md` and attribute documentation in `docs/resources/resource_secret.md` covering setting/rotating passwords and the state-safety guarantee.
 - `TestAccTSSSecret_PasswordNotInState`, `TestAccTSSSecret_RotateViaVersion`, `TestAccTSSSecret_ChangePwWithoutBumpIsNoop`, `TestAccTSSSecret_RefreshNoDrift` acceptance tests in `delinea/resource_secret_acceptance_test.go`.
 - `TestAccTSSSecret_SshKeyGeneration` and `TestAccTSSSecret_SshKeyAndPasswordMixed` acceptance tests, env-gated on `TSS_TEST_SSH_TEMPLATE_ID` and `TSS_TEST_MIXED_TEMPLATE_ID`. Verify `sshKeyFieldPlanModifier`'s server-side computation path and confirm non-interference with the password-handling changes for templates that contain both Password and SSH-key fields.
+- New `generate` Bool attribute on the `fields` block of `tss_resource_secret` — closes [gh #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110). When set to `true` on a password field, the provider asks Secret Server for a password matching the template's password-requirement policy (via `POST /api/v1/secret-templates/generate-password/{fieldId}`) and uses it as the field's value. The generated password reaches Secret Server through the normal create/update flow and is never written to Terraform state. Mutually exclusive with `password_value` and `itemvalue`. Rotates via `password_wo_version` bumps the same way `password_value` does.
+- New "Server-side password generation" section in `README.md` and `generate` attribute documentation in `docs/resources/resource_secret.md`.
+- `TestAccTSSSecret_GeneratePasswordFromTemplatePolicy`, `TestAccTSSSecret_GeneratePasswordRotation`, and `TestAccTSSSecret_GenerateNoBumpIsNoOp` acceptance tests covering create-with-generate, rotate-with-version-bump, and idempotent-no-rotate.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ fields {
 
 On plan, Terraform sees the `password_wo_version` change and schedules an update; on apply, the provider reads `password_value` from config and sends it to Secret Server. Any new integer works — only the change is significant.
 
+### Server-side password generation
+
+If you don't want to supply a password value yourself, set `generate = true` on the field. The provider asks Secret Server for a password matching the template's password-requirement policy and uses that value:
+
+```hcl
+resource "tss_resource_secret" "db" {
+  name             = "db-prod"
+  folderid         = "42"
+  siteid           = "1"
+  secrettemplateid = "2"
+
+  fields {
+    fieldname = "Username"
+    itemvalue = "dbadmin"
+  }
+  fields {
+    fieldname           = "Password"
+    generate            = true
+    password_wo_version = 1
+  }
+}
+```
+
+`generate` is mutually exclusive with `password_value` and (for password fields) `itemvalue` — the provider rejects configs that set both. Rotation works the same way as for `password_value`: bump `password_wo_version` to ask for a new generated password on the next apply. Re-applying with the same `password_wo_version` is a no-op (no API call to the generate endpoint, no rotation).
+
+The generated password reaches Secret Server through the normal create/update flow. It never lands in `terraform.tfstate` because `flattenSecret` nulls `itemvalue` for fields the template marks `IsPassword`.
+
 ### Guarantees and caveats
 
 - `terraform.tfstate` contains no plaintext password. Post-apply, `itemvalue` is `null` for any field the template marks `IsPassword`.

--- a/delinea/resource_secret.go
+++ b/delinea/resource_secret.go
@@ -52,6 +52,7 @@ type SecretField struct {
 	ItemValue         types.String `tfsdk:"itemvalue"`
 	PasswordValue     types.String `tfsdk:"password_value"`
 	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
+	Generate          types.Bool   `tfsdk:"generate"`
 	ItemID            types.Int64  `tfsdk:"itemid"`
 	FieldID           types.Int64  `tfsdk:"fieldid"`
 	FileAttachmentID  types.Int64  `tfsdk:"fileattachmentid"`
@@ -500,7 +501,11 @@ func (r *TSSSecretResource) Schema(ctx context.Context, req resource.SchemaReque
 						},
 						"password_wo_version": schema.Int64Attribute{
 							Optional:    true,
-							Description: "Rotation trigger for password_value. Bump this integer to signal Terraform that the password_value has changed and should be re-sent to TSS; any new value is fine, only the change matters.",
+							Description: "Rotation trigger for password_value or generate. Bump this integer to signal Terraform that the password_value has changed and should be re-sent to TSS, or that a new password should be generated when generate=true; any new value is fine, only the change matters.",
+						},
+						"generate": schema.BoolAttribute{
+							Optional:    true,
+							Description: "Request server-side password generation from the template's password-requirement policy (closes gh #110). Only honored on fields the template marks as password fields. Mutually exclusive with password_value and itemvalue. Pair with password_wo_version to rotate the generated password.",
 						},
 						"itemid": schema.Int64Attribute{
 							Optional: true,
@@ -698,9 +703,9 @@ func mergeWriteOnlyFieldValues(plan, config []SecretField) {
 //
 // For each matched field, user-set attributes that the TSS API does not round-trip
 // are copied from the reference into the aligned result: password_wo_version is
-// the rotation trigger for the write-only password_value attribute, so it lives
-// only on the Terraform side and must be preserved from plan (on Create/Update)
-// or prior state (on Read).
+// the rotation trigger for the write-only password_value attribute, and generate
+// is the request-server-side-generation flag — both live only on the Terraform
+// side and must be preserved from plan (on Create/Update) or prior state (on Read).
 func alignFieldsToReference(fields []SecretField, reference []SecretField) []SecretField {
 	if reference == nil {
 		return fields
@@ -713,6 +718,7 @@ func alignFieldsToReference(fields []SecretField, reference []SecretField) []Sec
 	for _, r := range reference {
 		if f, ok := byName[strings.ToLower(r.FieldName.ValueString())]; ok {
 			f.PasswordWoVersion = r.PasswordWoVersion
+			f.Generate = r.Generate
 			aligned = append(aligned, f)
 		}
 	}
@@ -754,11 +760,30 @@ func (r *TSSSecretResource) getSecretData(ctx context.Context, state *SecretReso
 			}
 		}
 
+		hasGenerate := !field.Generate.IsNull() && field.Generate.ValueBool()
 		hasPasswordValue := !field.PasswordValue.IsNull() && field.PasswordValue.ValueString() != ""
 		hasItemValue := !field.ItemValue.IsNull() && field.ItemValue.ValueString() != ""
 
+		if hasGenerate {
+			if !templateField.IsPassword {
+				return nil, fmt.Errorf("field %q has generate=true but is not a password field on template %q; only fields with isPassword=true support template-policy generation", fieldName, template.Name)
+			}
+			if hasPasswordValue {
+				return nil, fmt.Errorf("field %q has both generate=true and password_value set; they are mutually exclusive", fieldName)
+			}
+			if hasItemValue {
+				return nil, fmt.Errorf("field %q has both generate=true and itemvalue set; they are mutually exclusive on a password field", fieldName)
+			}
+		}
+
 		var itemValue string
 		switch {
+		case hasGenerate:
+			pw, err := client.GeneratePassword(templateField.FieldSlugName, template)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate password for field %q from template policy: %w", fieldName, err)
+			}
+			itemValue = pw
 		case hasPasswordValue:
 			itemValue = field.PasswordValue.ValueString()
 		case hasItemValue:

--- a/delinea/resource_secret_acceptance_test.go
+++ b/delinea/resource_secret_acceptance_test.go
@@ -122,6 +122,7 @@ type fieldSpec struct {
 	ItemValue         string // if non-empty, emit itemvalue
 	PasswordValue     string // if non-empty, emit password_value (write-only)
 	PasswordWoVersion int    // if non-zero, emit password_wo_version
+	Generate          bool   // if true, emit generate=true
 }
 
 func testAccSecretConfig(name string, fields ...fieldSpec) string {
@@ -136,6 +137,9 @@ func testAccSecretConfig(name string, fields ...fieldSpec) string {
 		}
 		if f.PasswordWoVersion != 0 {
 			fieldBlocks += fmt.Sprintf("    password_wo_version = %d\n", f.PasswordWoVersion)
+		}
+		if f.Generate {
+			fieldBlocks += "    generate = true\n"
 		}
 		fieldBlocks += "  }"
 	}
@@ -331,6 +335,86 @@ func TestAccTSSSecret_PasswordValueChangeWithoutVersionBumpIsNoOp(t *testing.T) 
 			{Config: step1},
 			{
 				Config:             step2,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// gh #110: Create with generate=true asks TSS for a password matching the
+// template's password-requirement policy and uses it as the field's
+// itemvalue. State has no plaintext password (same WriteOnly null behavior
+// as PasswordValue). The generated password should never appear in state.
+func TestAccTSSSecret_GeneratePasswordFromTemplatePolicy(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-generate")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretConfig(name,
+					fieldSpec{Name: "Username", ItemValue: "testuser"},
+					fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.generate", "true"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+// gh #110: Bumping password_wo_version while generate=true triggers an
+// Update; the provider re-calls the generate endpoint and TSS stores the
+// new generated password. State retains generate=true and the new version.
+func TestAccTSSSecret_GeneratePasswordRotation(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-gen-rotate")
+	step1 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+	)
+	step2 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 2},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: step1,
+				Check:  resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
+			},
+			{
+				Config: step2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "2"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+				),
+			},
+		},
+	})
+}
+
+// gh #110: re-applying a generate=true config without bumping
+// password_wo_version must be a no-op (no API call to generate-password,
+// no diff). Same property as the password_value case.
+func TestAccTSSSecret_GenerateNoBumpIsNoOp(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-gen-noop")
+	config := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/delinea/resource_secret_test.go
+++ b/delinea/resource_secret_test.go
@@ -257,6 +257,39 @@ func TestAlignFieldsToReference_NullPasswordWoVersionInReferenceStaysNull(t *tes
 	}
 }
 
+func TestAlignFieldsToReference_PreservesGenerateFromReference(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolValue(true)},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d fields, want 1", len(got))
+	}
+	if !got[0].Generate.ValueBool() {
+		t.Fatalf("got generate=%v, want true", got[0].Generate)
+	}
+}
+
+func TestAlignFieldsToReference_NullGenerateInReferenceStaysNull(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if !got[0].Generate.IsNull() {
+		t.Fatalf("got generate=%v, want null", got[0].Generate)
+	}
+}
+
 func TestFlattenSecret_NullsItemValueForPasswordFields(t *testing.T) {
 	secret := &server.Secret{
 		ID:   42,

--- a/docs/resources/resource_secret.md
+++ b/docs/resources/resource_secret.md
@@ -67,7 +67,8 @@ Optional:
 - `itemvalue` (String, Sensitive) The value of the field. For password fields, prefer `password_value` — `itemvalue` is nulled in state on read, which produces a perpetual diff if used for a password.
 - `listtype` (String)
 - `password_value` (String, Sensitive, Write-only) Password value for password fields. Never stored in Terraform state. Requires Terraform 1.11+. Pair with `password_wo_version` to trigger rotation.
-- `password_wo_version` (Number) Rotation trigger for `password_value`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server on the next apply.
+- `password_wo_version` (Number) Rotation trigger for `password_value` or `generate`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server, or to ask for a new generated password when `generate=true`, on the next apply.
+- `generate` (Boolean) Request server-side password generation from the template's password-requirement policy. Only honored on fields the template marks as password fields. Mutually exclusive with `password_value` and `itemvalue`. Pair with `password_wo_version` to rotate. Closes [GitHub issue #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110).
 - `slug` (String)
 
 


### PR DESCRIPTION
[Task 726495](https://dev.azure.com/thycotic/Delinea.Work/_workitems/edit/726495)

> ⚠ **Stacked on #126.** This PR is based on `dbinger-pbi-700142` rather than `dev/v4.0.0`. **Do not merge** until #126 (and #124, #125 before it) have merged and this PR's base has flipped to `dev/v4.0.0`. Held in draft for that reason.

Closes [gh #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110) — paying customer reported they couldn't get Secret Server to generate a password from the template's password-requirement policy via Terraform.

## TSS API behavior (verified)

Verified 2026-04-30 against `dbinger.dart.devsecretservercloud.com`, template 2 / Password field id 7:

- Empty / null `itemValue` is **rejected** with `API_RequiredFieldMissing`. The reporter's claim that empty string triggers generation was wrong.
- Dedicated endpoint: `POST /api/v1/secret-templates/generate-password/{secretTemplateFieldId}` returns a string password matching the field's `passwordRequirementId` policy. Works for both Create (POST) and Update (PUT). Rotation verified end-to-end.
- Already exposed by the SDK as `server.GeneratePassword(slug, template)`. No new API code required on our side.

## Changes

- **Schema**: new `generate` Bool attribute on the `fields` block of `tss_resource_secret`. Optional, default null/false.
- **`getSecretData` precedence**: `generate=true` wins over `password_value`, `itemvalue`, and the omit-on-null fallback. Calls `client.GeneratePassword(slug, template)` and uses the returned password as the field's `ItemValue` in the API payload.
- **Mutual exclusion**, enforced at apply time:
  - `generate=true` + `password_value` set → config error
  - `generate=true` + `itemvalue` set on a password field → config error
  - `generate=true` on a non-password field → config error (the template's `IsPassword` flag determines what's a password field)
- **`alignFieldsToReference`** now preserves `Generate` from the reference slice (config-only, not round-tripped from TSS) — same shape as `password_wo_version`.
- **Rotation**: bump `password_wo_version` while `generate=true` to ask for a new generated password on the next apply. Re-applying with the same `password_wo_version` is a no-op (no API call to the generate endpoint).
- **State**: nothing new lands in state. The generated password reaches Secret Server through the normal create/update flow; `flattenSecret` already nulls `itemvalue` for fields the template marks `IsPassword`, so generated passwords never appear in `terraform.tfstate` or `terraform show -json`.

## Tests

- Unit: `TestAlignFieldsToReference_PreservesGenerateFromReference`, `TestAlignFieldsToReference_NullGenerateInReferenceStaysNull`.
- Acceptance (env-gated on `TF_ACC=1` and tenant env vars): `TestAccTSSSecret_GeneratePasswordFromTemplatePolicy`, `TestAccTSSSecret_GeneratePasswordRotation`, `TestAccTSSSecret_GenerateNoBumpIsNoOp`.

## Docs

- `README.md` — new "Server-side password generation" subsection under "Password handling" with config example.
- `docs/resources/resource_secret.md` — `generate` attribute description with link to gh #110.
- `CHANGELOG.md` — `Added` entry under `[Unreleased]`.

## QA

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` clean (unit tests; acceptance tests self-skip without `TF_ACC=1`).
- [ ] `TF_ACC=1` acceptance run against a live tenant: create with `generate=true`, rotate via `password_wo_version` bump, idempotent no-bump no-op. To be done as part of Task 8 (QA pass) once the full stack is on `dev/v4.0.0`.
- [ ] Manual: `generate=true` + `password_value` together produces a clear config error; `generate=true` on Username (non-password) field produces a clear config error. Same Task-8 timing.
- [ ] CI workflow runs and passes on this PR (Snyk caveat from #124 still applies).
