### PR TITLE
[5/8] 726496: Lock down server-assigned fields on tss_resource_secret (PBI 718755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 - New "Password handling" section in `README.md` and attribute documentation in `docs/resources/resource_secret.md` covering setting/rotating passwords and the state-safety guarantee.
 - `TestAccTSSSecret_PasswordNotInState`, `TestAccTSSSecret_RotateViaVersion`, `TestAccTSSSecret_ChangePwWithoutBumpIsNoop`, `TestAccTSSSecret_RefreshNoDrift` acceptance tests in `delinea/resource_secret_acceptance_test.go`.
 - `TestAccTSSSecret_SshKeyGeneration` and `TestAccTSSSecret_SshKeyAndPasswordMixed` acceptance tests, env-gated on `TSS_TEST_SSH_TEMPLATE_ID` and `TSS_TEST_MIXED_TEMPLATE_ID`. Verify `sshKeyFieldPlanModifier`'s server-side computation path and confirm non-interference with the password-handling changes for templates that contain both Password and SSH-key fields.
+- New `generate` Bool attribute on the `fields` block of `tss_resource_secret` — closes [gh #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110). When set to `true` on a password field, the provider asks Secret Server for a password matching the template's password-requirement policy (via `POST /api/v1/secret-templates/generate-password/{fieldId}`) and uses it as the field's value. The generated password reaches Secret Server through the normal create/update flow and is never written to Terraform state. Mutually exclusive with `password_value` and `itemvalue`. Rotates via `password_wo_version` bumps the same way `password_value` does.
+- New "Server-side password generation" section in `README.md` and `generate` attribute documentation in `docs/resources/resource_secret.md`.
+- `TestAccTSSSecret_GeneratePasswordFromTemplatePolicy`, `TestAccTSSSecret_GeneratePasswordRotation`, and `TestAccTSSSecret_GenerateNoBumpIsNoOp` acceptance tests covering create-with-generate, rotate-with-version-bump, and idempotent-no-rotate.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 ### Breaking
 
 - Documented Terraform floor raised from 0.13 to **1.11**. `tss_resource_secret`'s new write-only password attribute requires Terraform 1.11. `README.md`, `docs/index.md`, and `examples/secrets/*.tf` (7 example configurations) updated accordingly. Users on Terraform &lt; 1.11 will see an `Unsupported Terraform Core version` error at `terraform init` once on v4.0.0.
+- `itemid`, `fieldid`, `slug`, and `fielddescription` on `tss_resource_secret.fields` are now `Computed`-only (closes PBI 718755). Configurations that set any of these four attributes in `fields` blocks will fail at plan time with `Can't configure a value for X: its value will be decided automatically based on the result of applying this configuration`. These values are server-assigned by Secret Server; the previous `Optional+Computed` declaration silently accepted user input and then overwrote it. **Migration:** delete those attributes from your `fields` blocks. `fileattachmentid` remains `Optional+Computed` because it is genuinely user-settable for file-type fields.
 
 ### Security
 
@@ -29,6 +30,9 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 - New `generate` Bool attribute on the `fields` block of `tss_resource_secret` — closes [gh #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110). When set to `true` on a password field, the provider asks Secret Server for a password matching the template's password-requirement policy (via `POST /api/v1/secret-templates/generate-password/{fieldId}`) and uses it as the field's value. The generated password reaches Secret Server through the normal create/update flow and is never written to Terraform state. Mutually exclusive with `password_value` and `itemvalue`. Rotates via `password_wo_version` bumps the same way `password_value` does.
 - New "Server-side password generation" section in `README.md` and `generate` attribute documentation in `docs/resources/resource_secret.md`.
 - `TestAccTSSSecret_GeneratePasswordFromTemplatePolicy`, `TestAccTSSSecret_GeneratePasswordRotation`, and `TestAccTSSSecret_GenerateNoBumpIsNoOp` acceptance tests covering create-with-generate, rotate-with-version-bump, and idempotent-no-rotate.
+- `Description` strings on the `itemid`, `fieldid`, `fileattachmentid`, `slug`, and `fielddescription` schema attributes so `terraform providers schema -json` and `tfplugindocs` output explain each one.
+- "Computed fields on `tss_resource_secret.fields`" section in `README.md` and matching content (Read-Only attribute list + "Computed Fields" subsection) in `docs/resources/resource_secret.md`. Addresses the customer-reported documentation gap on "auto-incrementing key fields" (closes PBI 718755).
+- `TestSchema_ServerAssignedFieldsAreComputedOnly` and `TestSchema_FileAttachmentIDIsOptionalAndComputed` schema-contract unit tests guarding the new `Computed`-only declarations.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ The generated password reaches Secret Server through the normal create/update fl
 - Legacy configs that set `itemvalue` on a password field still work, but `flattenSecret` now nulls the value in state, which produces a perpetual plan diff. Migrate those fields to `password_value` + `password_wo_version`.
 - Upgrading from v3.1.x or earlier: existing state files still contain plaintext passwords. The first `terraform apply` or `terraform refresh` after the upgrade will null them; no data loss, just state cleanup.
 
+## Computed fields on `tss_resource_secret.fields`
+
+Each `fields` block has attributes that Secret Server assigns automatically after `terraform apply`. They appear in Terraform state but are not user-settable:
+
+- `itemid` — database ID of this field-value record. Auto-assigned by Secret Server; sequential per newly-created secret.
+- `fieldid` — the template field ID. Stable per template, shared across every secret that uses the template. Not sequential.
+- `slug` — the field's URL slug, assigned by the template.
+- `fielddescription` — the field description, set by the template.
+
+Setting any of these four in your config produces a plan error ("Can't configure a value for `itemid`: its value will be decided automatically based on the result of applying this configuration"). That's the signal that these are server-assigned — leave them out.
+
+One exception: `fileattachmentid` is both `Computed` and `Optional`. It's genuinely user-settable for file-type fields (you can point an existing attachment at this field), and populated automatically for non-file fields.
+
 ## Delete Secret by ID
 
 The `tss_secret_deletion` resource allows you to delete secrets by their ID, even if they are not managed by Terraform state.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ fields {
 
 On plan, Terraform sees the `password_wo_version` change and schedules an update; on apply, the provider reads `password_value` from config and sends it to Secret Server. Any new integer works — only the change is significant.
 
+### Server-side password generation
+
+If you don't want to supply a password value yourself, set `generate = true` on the field. The provider asks Secret Server for a password matching the template's password-requirement policy and uses that value:
+
+```hcl
+resource "tss_resource_secret" "db" {
+  name             = "db-prod"
+  folderid         = "42"
+  siteid           = "1"
+  secrettemplateid = "2"
+
+  fields {
+    fieldname = "Username"
+    itemvalue = "dbadmin"
+  }
+  fields {
+    fieldname           = "Password"
+    generate            = true
+    password_wo_version = 1
+  }
+}
+```
+
+`generate` is mutually exclusive with `password_value` and (for password fields) `itemvalue` — the provider rejects configs that set both. Rotation works the same way as for `password_value`: bump `password_wo_version` to ask for a new generated password on the next apply. Re-applying with the same `password_wo_version` is a no-op (no API call to the generate endpoint, no rotation).
+
+The generated password reaches Secret Server through the normal create/update flow. It never lands in `terraform.tfstate` because `flattenSecret` nulls `itemvalue` for fields the template marks `IsPassword`.
+
 ### Guarantees and caveats
 
 - `terraform.tfstate` contains no plaintext password. Post-apply, `itemvalue` is `null` for any field the template marks `IsPassword`.

--- a/delinea/resource_secret.go
+++ b/delinea/resource_secret.go
@@ -508,24 +508,25 @@ func (r *TSSSecretResource) Schema(ctx context.Context, req resource.SchemaReque
 							Description: "Request server-side password generation from the template's password-requirement policy (closes gh #110). Only honored on fields the template marks as password fields. Mutually exclusive with password_value and itemvalue. Pair with password_wo_version to rotate the generated password.",
 						},
 						"itemid": schema.Int64Attribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Server-assigned database ID of this field-value record. Populated after apply; do not set in config.",
 						},
 						"fieldid": schema.Int64Attribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Secret Server template field ID; stable per template, shared across every secret that uses the template. Populated after apply; do not set in config.",
 						},
 						"fileattachmentid": schema.Int64Attribute{
-							Optional: true,
-							Computed: true,
+							Optional:    true,
+							Computed:    true,
+							Description: "File attachment ID. Only meaningful for file-type fields; genuinely user-settable there as an alternative to uploading a new file.",
 						},
 						"slug": schema.StringAttribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Field's URL slug, assigned by the template. Populated after apply; do not set in config.",
 						},
 						"fielddescription": schema.StringAttribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Field description from the template. Populated after apply; do not set in config.",
 						},
 						"filename": schema.StringAttribute{
 							Optional: true,

--- a/delinea/resource_secret.go
+++ b/delinea/resource_secret.go
@@ -52,6 +52,7 @@ type SecretField struct {
 	ItemValue         types.String `tfsdk:"itemvalue"`
 	PasswordValue     types.String `tfsdk:"password_value"`
 	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
+	Generate          types.Bool   `tfsdk:"generate"`
 	ItemID            types.Int64  `tfsdk:"itemid"`
 	FieldID           types.Int64  `tfsdk:"fieldid"`
 	FileAttachmentID  types.Int64  `tfsdk:"fileattachmentid"`
@@ -500,7 +501,11 @@ func (r *TSSSecretResource) Schema(ctx context.Context, req resource.SchemaReque
 						},
 						"password_wo_version": schema.Int64Attribute{
 							Optional:    true,
-							Description: "Rotation trigger for password_value. Bump this integer to signal Terraform that the password_value has changed and should be re-sent to TSS; any new value is fine, only the change matters.",
+							Description: "Rotation trigger for password_value or generate. Bump this integer to signal Terraform that the password_value has changed and should be re-sent to TSS, or that a new password should be generated when generate=true; any new value is fine, only the change matters.",
+						},
+						"generate": schema.BoolAttribute{
+							Optional:    true,
+							Description: "Request server-side password generation from the template's password-requirement policy (closes gh #110). Only honored on fields the template marks as password fields. Mutually exclusive with password_value and itemvalue. Pair with password_wo_version to rotate the generated password.",
 						},
 						"itemid": schema.Int64Attribute{
 							Optional: true,
@@ -698,9 +703,9 @@ func mergeWriteOnlyFieldValues(plan, config []SecretField) {
 //
 // For each matched field, user-set attributes that the TSS API does not round-trip
 // are copied from the reference into the aligned result: password_wo_version is
-// the rotation trigger for the write-only password_value attribute, so it lives
-// only on the Terraform side and must be preserved from plan (on Create/Update)
-// or prior state (on Read).
+// the rotation trigger for the write-only password_value attribute, and generate
+// is the request-server-side-generation flag — both live only on the Terraform
+// side and must be preserved from plan (on Create/Update) or prior state (on Read).
 func alignFieldsToReference(fields []SecretField, reference []SecretField) []SecretField {
 	if reference == nil {
 		return fields
@@ -713,6 +718,7 @@ func alignFieldsToReference(fields []SecretField, reference []SecretField) []Sec
 	for _, r := range reference {
 		if f, ok := byName[strings.ToLower(r.FieldName.ValueString())]; ok {
 			f.PasswordWoVersion = r.PasswordWoVersion
+			f.Generate = r.Generate
 			aligned = append(aligned, f)
 		}
 	}
@@ -754,11 +760,30 @@ func (r *TSSSecretResource) getSecretData(ctx context.Context, state *SecretReso
 			}
 		}
 
+		hasGenerate := !field.Generate.IsNull() && field.Generate.ValueBool()
 		hasPasswordValue := !field.PasswordValue.IsNull() && field.PasswordValue.ValueString() != ""
 		hasItemValue := !field.ItemValue.IsNull() && field.ItemValue.ValueString() != ""
 
+		if hasGenerate {
+			if !templateField.IsPassword {
+				return nil, fmt.Errorf("field %q has generate=true but is not a password field on template %q; only fields with isPassword=true support template-policy generation", fieldName, template.Name)
+			}
+			if hasPasswordValue {
+				return nil, fmt.Errorf("field %q has both generate=true and password_value set; they are mutually exclusive", fieldName)
+			}
+			if hasItemValue {
+				return nil, fmt.Errorf("field %q has both generate=true and itemvalue set; they are mutually exclusive on a password field", fieldName)
+			}
+		}
+
 		var itemValue string
 		switch {
+		case hasGenerate:
+			pw, err := client.GeneratePassword(templateField.FieldSlugName, template)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate password for field %q from template policy: %w", fieldName, err)
+			}
+			itemValue = pw
 		case hasPasswordValue:
 			itemValue = field.PasswordValue.ValueString()
 		case hasItemValue:

--- a/delinea/resource_secret_acceptance_test.go
+++ b/delinea/resource_secret_acceptance_test.go
@@ -122,6 +122,7 @@ type fieldSpec struct {
 	ItemValue         string // if non-empty, emit itemvalue
 	PasswordValue     string // if non-empty, emit password_value (write-only)
 	PasswordWoVersion int    // if non-zero, emit password_wo_version
+	Generate          bool   // if true, emit generate=true
 }
 
 func testAccSecretConfig(name string, fields ...fieldSpec) string {
@@ -136,6 +137,9 @@ func testAccSecretConfig(name string, fields ...fieldSpec) string {
 		}
 		if f.PasswordWoVersion != 0 {
 			fieldBlocks += fmt.Sprintf("    password_wo_version = %d\n", f.PasswordWoVersion)
+		}
+		if f.Generate {
+			fieldBlocks += "    generate = true\n"
 		}
 		fieldBlocks += "  }"
 	}
@@ -331,6 +335,86 @@ func TestAccTSSSecret_PasswordValueChangeWithoutVersionBumpIsNoOp(t *testing.T) 
 			{Config: step1},
 			{
 				Config:             step2,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// gh #110: Create with generate=true asks TSS for a password matching the
+// template's password-requirement policy and uses it as the field's
+// itemvalue. State has no plaintext password (same WriteOnly null behavior
+// as PasswordValue). The generated password should never appear in state.
+func TestAccTSSSecret_GeneratePasswordFromTemplatePolicy(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-generate")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretConfig(name,
+					fieldSpec{Name: "Username", ItemValue: "testuser"},
+					fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.generate", "true"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+// gh #110: Bumping password_wo_version while generate=true triggers an
+// Update; the provider re-calls the generate endpoint and TSS stores the
+// new generated password. State retains generate=true and the new version.
+func TestAccTSSSecret_GeneratePasswordRotation(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-gen-rotate")
+	step1 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+	)
+	step2 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 2},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: step1,
+				Check:  resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
+			},
+			{
+				Config: step2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "2"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+				),
+			},
+		},
+	})
+}
+
+// gh #110: re-applying a generate=true config without bumping
+// password_wo_version must be a no-op (no API call to generate-password,
+// no diff). Same property as the password_value case.
+func TestAccTSSSecret_GenerateNoBumpIsNoOp(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-gen-noop")
+	config := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/delinea/resource_secret_test.go
+++ b/delinea/resource_secret_test.go
@@ -257,6 +257,39 @@ func TestAlignFieldsToReference_NullPasswordWoVersionInReferenceStaysNull(t *tes
 	}
 }
 
+func TestAlignFieldsToReference_PreservesGenerateFromReference(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolValue(true)},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d fields, want 1", len(got))
+	}
+	if !got[0].Generate.ValueBool() {
+		t.Fatalf("got generate=%v, want true", got[0].Generate)
+	}
+}
+
+func TestAlignFieldsToReference_NullGenerateInReferenceStaysNull(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if !got[0].Generate.IsNull() {
+		t.Fatalf("got generate=%v, want null", got[0].Generate)
+	}
+}
+
 func TestFlattenSecret_NullsItemValueForPasswordFields(t *testing.T) {
 	secret := &server.Secret{
 		ID:   42,

--- a/delinea/resource_secret_test.go
+++ b/delinea/resource_secret_test.go
@@ -1,11 +1,14 @@
 package delinea
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/DelineaXPM/tss-sdk-go/v2/server"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -424,4 +427,54 @@ func Example_alignFieldsToReference_refresh() {
 	// Output:
 	// Username
 	// Password
+}
+
+func fieldsBlockAttributes(t *testing.T) map[string]schema.Attribute {
+	t.Helper()
+	r := &TSSSecretResource{}
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Schema() returned diagnostics: %v", resp.Diagnostics)
+	}
+	block, ok := resp.Schema.Blocks["fields"].(schema.ListNestedBlock)
+	if !ok {
+		t.Fatalf("fields block missing or wrong type: %T", resp.Schema.Blocks["fields"])
+	}
+	return block.NestedObject.Attributes
+}
+
+// PBI 718755: these four attributes are server-assigned. Declaring them
+// Computed-only (no Optional) is what makes Terraform reject configs that try
+// to set them, which is the diagnostic the customer needed.
+func TestSchema_ServerAssignedFieldsAreComputedOnly(t *testing.T) {
+	attrs := fieldsBlockAttributes(t)
+	for _, name := range []string{"itemid", "fieldid", "slug", "fielddescription"} {
+		attr, ok := attrs[name]
+		if !ok {
+			t.Fatalf("%s: attribute missing from fields block", name)
+		}
+		if !attr.IsComputed() {
+			t.Errorf("%s: IsComputed() = false, want true", name)
+		}
+		if attr.IsOptional() {
+			t.Errorf("%s: IsOptional() = true, want false (setting in config must produce a plan-time error)", name)
+		}
+	}
+}
+
+// fileattachmentid is the documented exception: it is genuinely user-settable
+// on file-type fields, so it must stay Optional+Computed.
+func TestSchema_FileAttachmentIDIsOptionalAndComputed(t *testing.T) {
+	attrs := fieldsBlockAttributes(t)
+	attr, ok := attrs["fileattachmentid"]
+	if !ok {
+		t.Fatal("fileattachmentid: attribute missing from fields block")
+	}
+	if !attr.IsOptional() {
+		t.Error("fileattachmentid: IsOptional() = false, want true")
+	}
+	if !attr.IsComputed() {
+		t.Error("fileattachmentid: IsComputed() = false, want true")
+	}
 }

--- a/docs/resources/resource_secret.md
+++ b/docs/resources/resource_secret.md
@@ -56,9 +56,7 @@ Required:
 
 Optional:
 
-- `fielddescription` (String)
-- `fieldid` (Number)
-- `fileattachmentid` (Number)
+- `fileattachmentid` (Number) File attachment ID. Only meaningful for file-type fields; genuinely user-settable there as an alternative to uploading a new file.
 - `filename` (String)
 - `isfile` (Boolean)
 - `islist` (Boolean)
@@ -69,7 +67,13 @@ Optional:
 - `password_value` (String, Sensitive, Write-only) Password value for password fields. Never stored in Terraform state. Requires Terraform 1.11+. Pair with `password_wo_version` to trigger rotation.
 - `password_wo_version` (Number) Rotation trigger for `password_value` or `generate`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server, or to ask for a new generated password when `generate=true`, on the next apply.
 - `generate` (Boolean) Request server-side password generation from the template's password-requirement policy. Only honored on fields the template marks as password fields. Mutually exclusive with `password_value` and `itemvalue`. Pair with `password_wo_version` to rotate. Closes [GitHub issue #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110).
-- `slug` (String)
+
+Read-Only:
+
+- `fielddescription` (String) Field description from the template. Populated after apply; do not set in config.
+- `fieldid` (Number) Secret Server template field ID; stable per template, shared across every secret that uses the template. Populated after apply; do not set in config.
+- `itemid` (Number) Server-assigned database ID of this field-value record. Populated after apply; do not set in config.
+- `slug` (String) Field's URL slug, assigned by the template. Populated after apply; do not set in config.
 
 
 <a id="nestedblock--sshkeyargs"></a>
@@ -141,3 +145,16 @@ resource "tss_resource_secret" "example" {
 ```
 
 To rotate the password, change `password_value` and bump `password_wo_version` (any new integer) in the same apply. The provider detects the version change and pushes the new value to Secret Server. See the README's "Password handling" section for the full guarantees and the upgrade path from pre-v4.0.0 state files.
+
+### Computed Fields
+
+Each `fields` block has attributes that Secret Server assigns automatically after `terraform apply`. They appear in Terraform state but are not user-settable:
+
+- `itemid` — database ID of this field-value record. Auto-assigned by Secret Server; sequential per newly-created secret.
+- `fieldid` — the template field ID. Stable per template, shared across every secret that uses the template. Not sequential.
+- `slug` — the field's URL slug, assigned by the template.
+- `fielddescription` — the field description, set by the template.
+
+Setting any of these four in your config produces a plan error ("Can't configure a value for `itemid`: its value will be decided automatically based on the result of applying this configuration"). That's the signal that these are server-assigned — leave them out.
+
+One exception: `fileattachmentid` is both `Computed` and `Optional`. It's genuinely user-settable for file-type fields (you can point an existing attachment at this field), and populated automatically for non-file fields.

--- a/docs/resources/resource_secret.md
+++ b/docs/resources/resource_secret.md
@@ -67,7 +67,8 @@ Optional:
 - `itemvalue` (String, Sensitive) The value of the field. For password fields, prefer `password_value` — `itemvalue` is nulled in state on read, which produces a perpetual diff if used for a password.
 - `listtype` (String)
 - `password_value` (String, Sensitive, Write-only) Password value for password fields. Never stored in Terraform state. Requires Terraform 1.11+. Pair with `password_wo_version` to trigger rotation.
-- `password_wo_version` (Number) Rotation trigger for `password_value`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server on the next apply.
+- `password_wo_version` (Number) Rotation trigger for `password_value` or `generate`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server, or to ask for a new generated password when `generate=true`, on the next apply.
+- `generate` (Boolean) Request server-side password generation from the template's password-requirement policy. Only honored on fields the template marks as password fields. Mutually exclusive with `password_value` and `itemvalue`. Pair with `password_wo_version` to rotate. Closes [GitHub issue #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110).
 - `slug` (String)
 
 


### PR DESCRIPTION
[Task 726496](https://dev.azure.com/thycotic/Delinea.Work/_workitems/edit/726496)

> ⚠ **Stacked on #127.** This PR is based on `dbinger-gh-110` rather than `dev/v4.0.0`. **Do not merge** until #127 (and #124, #125, #126 before it) have merged and this PR's base has flipped to `dev/v4.0.0`. Held in draft for that reason.

PBI 718755: a customer reported that the documentation didn't explain how to deal with "auto-incrementing key fields" on `tss_resource_secret`. The root cause is that `itemid`, `fieldid`, `slug`, and `fielddescription` were declared `Optional+Computed` — Terraform silently accepted user-supplied values on plan, then the server overwrote them on apply. The fix makes them `Computed`-only, so plan rejects any attempt to set them with a clear error.

## Changes

- **Schema** (`delinea/resource_secret.go` `fields` block): drop `Optional: true` from `itemid`, `fieldid`, `slug`, and `fielddescription`. Keep `fileattachmentid` as `Optional+Computed` (genuinely user-settable for file-type fields).
- **`Description` strings** on all five attributes — surfaces in `terraform providers schema -json` and `tfplugindocs` output, so the docs explain what each one is and which are computed.
- **Docs**:
  - `README.md` — new "Computed fields on `tss_resource_secret.fields`" section listing the four computed attributes and the `fileattachmentid` exception.
  - `docs/resources/resource_secret.md` — `itemid`/`fieldid`/`slug`/`fielddescription` moved into a `Read-Only` block; new "Computed Fields" subsection mirrors the README content.
- **CHANGELOG.md**: Breaking entry for the `Optional` drop, Added entries for descriptions / doc sections / schema-contract tests.

## Breaking change

Configurations that set any of `itemid`, `fieldid`, `slug`, or `fielddescription` on a `fields` block will fail at plan time after this lands:

```
Error: Can't configure a value for `itemid`: its value will be decided
automatically based on the result of applying this configuration.
```

Migration: delete those attributes from your config. They were never useful — the server-assigned values overwrote them anyway.

## Tests

- `TestSchema_ServerAssignedFieldsAreComputedOnly` — verifies `itemid`, `fieldid`, `slug`, `fielddescription` are all `IsComputed() && !IsOptional()`.
- `TestSchema_FileAttachmentIDIsOptionalAndComputed` — verifies the documented exception holds.

## QA

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` clean (schema-contract tests exercise the new declarations directly; no live tenant required).
- [ ] Manual: a config that sets `itemid` on a `fields` block produces the plan-time error referenced above. Same Task-8 timing.
- [ ] Manual: a config that uses `fileattachmentid` on a file-type field still works (the exception holds).
- [ ] CI workflow runs and passes on this PR (Snyk caveat from #124 still applies).
