### PR TITLE
[6/8] 726497: State upgrader v3 → v4 schema (gh #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 - New "Password handling" section in `README.md` and attribute documentation in `docs/resources/resource_secret.md` covering setting/rotating passwords and the state-safety guarantee.
 - `TestAccTSSSecret_PasswordNotInState`, `TestAccTSSSecret_RotateViaVersion`, `TestAccTSSSecret_ChangePwWithoutBumpIsNoop`, `TestAccTSSSecret_RefreshNoDrift` acceptance tests in `delinea/resource_secret_acceptance_test.go`.
 - `TestAccTSSSecret_SshKeyGeneration` and `TestAccTSSSecret_SshKeyAndPasswordMixed` acceptance tests, env-gated on `TSS_TEST_SSH_TEMPLATE_ID` and `TSS_TEST_MIXED_TEMPLATE_ID`. Verify `sshKeyFieldPlanModifier`'s server-side computation path and confirm non-interference with the password-handling changes for templates that contain both Password and SSH-key fields.
+- New `generate` Bool attribute on the `fields` block of `tss_resource_secret` — closes [gh #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110). When set to `true` on a password field, the provider asks Secret Server for a password matching the template's password-requirement policy (via `POST /api/v1/secret-templates/generate-password/{fieldId}`) and uses it as the field's value. The generated password reaches Secret Server through the normal create/update flow and is never written to Terraform state. Mutually exclusive with `password_value` and `itemvalue`. Rotates via `password_wo_version` bumps the same way `password_value` does.
+- New "Server-side password generation" section in `README.md` and `generate` attribute documentation in `docs/resources/resource_secret.md`.
+- `TestAccTSSSecret_GeneratePasswordFromTemplatePolicy`, `TestAccTSSSecret_GeneratePasswordRotation`, and `TestAccTSSSecret_GenerateNoBumpIsNoOp` acceptance tests covering create-with-generate, rotate-with-version-bump, and idempotent-no-rotate.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 ### Breaking
 
 - Documented Terraform floor raised from 0.13 to **1.11**. `tss_resource_secret`'s new write-only password attribute requires Terraform 1.11. `README.md`, `docs/index.md`, and `examples/secrets/*.tf` (7 example configurations) updated accordingly. Users on Terraform &lt; 1.11 will see an `Unsupported Terraform Core version` error at `terraform init` once on v4.0.0.
+- `itemid`, `fieldid`, `slug`, and `fielddescription` on `tss_resource_secret.fields` are now `Computed`-only (closes PBI 718755). Configurations that set any of these four attributes in `fields` blocks will fail at plan time with `Can't configure a value for X: its value will be decided automatically based on the result of applying this configuration`. These values are server-assigned by Secret Server; the previous `Optional+Computed` declaration silently accepted user input and then overwrote it. **Migration:** delete those attributes from your `fields` blocks. `fileattachmentid` remains `Optional+Computed` because it is genuinely user-settable for file-type fields.
 
 ### Security
 
@@ -29,6 +30,9 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 - New `generate` Bool attribute on the `fields` block of `tss_resource_secret` — closes [gh #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110). When set to `true` on a password field, the provider asks Secret Server for a password matching the template's password-requirement policy (via `POST /api/v1/secret-templates/generate-password/{fieldId}`) and uses it as the field's value. The generated password reaches Secret Server through the normal create/update flow and is never written to Terraform state. Mutually exclusive with `password_value` and `itemvalue`. Rotates via `password_wo_version` bumps the same way `password_value` does.
 - New "Server-side password generation" section in `README.md` and `generate` attribute documentation in `docs/resources/resource_secret.md`.
 - `TestAccTSSSecret_GeneratePasswordFromTemplatePolicy`, `TestAccTSSSecret_GeneratePasswordRotation`, and `TestAccTSSSecret_GenerateNoBumpIsNoOp` acceptance tests covering create-with-generate, rotate-with-version-bump, and idempotent-no-rotate.
+- `Description` strings on the `itemid`, `fieldid`, `fileattachmentid`, `slug`, and `fielddescription` schema attributes so `terraform providers schema -json` and `tfplugindocs` output explain each one.
+- "Computed fields on `tss_resource_secret.fields`" section in `README.md` and matching content (Read-Only attribute list + "Computed Fields" subsection) in `docs/resources/resource_secret.md`. Addresses the customer-reported documentation gap on "auto-incrementing key fields" (closes PBI 718755).
+- `TestSchema_ServerAssignedFieldsAreComputedOnly` and `TestSchema_FileAttachmentIDIsOptionalAndComputed` schema-contract unit tests guarding the new `Computed`-only declarations.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ For the release history prior to v4.0.0, see the [GitHub Releases](https://githu
 - `Description` strings on the `itemid`, `fieldid`, `fileattachmentid`, `slug`, and `fielddescription` schema attributes so `terraform providers schema -json` and `tfplugindocs` output explain each one.
 - "Computed fields on `tss_resource_secret.fields`" section in `README.md` and matching content (Read-Only attribute list + "Computed Fields" subsection) in `docs/resources/resource_secret.md`. Addresses the customer-reported documentation gap on "auto-incrementing key fields" (closes PBI 718755).
 - `TestSchema_ServerAssignedFieldsAreComputedOnly` and `TestSchema_FileAttachmentIDIsOptionalAndComputed` schema-contract unit tests guarding the new `Computed`-only declarations.
+- State upgrader for v3.x → v4 schema (closes [gh #106](https://github.com/DelineaXPM/terraform-provider-tss/issues/106) for v3 source state). `tss_resource_secret`'s schema is now versioned (`Version: 1`) and the resource implements `ResourceWithUpgradeState`. v3.x state files (which had no version recorded by the framework) are upgraded by reading the prior state with a v3-shaped schema, copying every attribute across, and leaving the new v4 attributes (`password_value`, `password_wo_version`, `generate`) at their null defaults. v2.x state is **not** auto-upgradeable — its SDKv2 shape is incompatible with the modern framework. v2.x users should follow the migration paths documented in the new "Upgrading state from earlier provider versions" section of `README.md` (stay on v2.x, drop and recreate state, or manual state surgery).
+- `TestUpgradeFieldsV0ToV1_*` and `TestPriorSchemaV0_*` unit tests covering the upgrader's field-copy contract and the v3-shaped prior schema.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,32 @@ Setting any of these four in your config produces a plan error ("Can't configure
 
 One exception: `fileattachmentid` is both `Computed` and `Optional`. It's genuinely user-settable for file-type fields (you can point an existing attachment at this field), and populated automatically for non-file fields.
 
+## Upgrading state from earlier provider versions
+
+### From v3.x to v4.0.0
+
+`terraform-provider-tss` v4.0.0 versions the schema (`Version: 1`) and ships a state upgrader that runs automatically the first time `terraform plan` is invoked against existing v3.x state. No user action is required. The upgrader carries every existing field across and leaves the new v4 attributes (`password_value`, `password_wo_version`, `generate`) at their null defaults.
+
+If you used `itemvalue` to supply a password on a `tss_resource_secret` field, the post-upgrade plan will show the value being null'd in state (because v4 nulls `itemvalue` for `IsPassword` fields). The first apply pushes that null to nothing — your password in TSS is unchanged. Migrate the password to `password_value` + `password_wo_version` at your convenience to avoid the perpetual diff that the legacy `itemvalue` path produces.
+
+### From v2.x to v4.0.0
+
+**v2.x and v4.0.0 are not directly compatible at the state level.** v2.x used Terraform's older Plugin SDKv2; v3+ switched to the modern Plugin Framework, which uses a different on-disk state shape. v4.0.0 does not include a v2 → v4 upgrader — translating SDKv2 state to framework state is substantial separate work that we have deferred.
+
+If you are still on v2.x, choose one of the following paths:
+
+1. **Stay on v2.x.** Reasonable for stable production where the resource isn't actively churning and the security/feature additions in v3+ aren't required. v2.x continues to function indefinitely against TSS.
+
+2. **Drop and recreate state** (recommended for most v2 → v4 migrations):
+   - For each affected resource: `terraform state rm tss_resource_secret.X`
+   - Adjust your config so the recreated resource doesn't collide on `name` with the existing secret in TSS, **or** delete the corresponding secret from TSS first.
+   - `terraform apply` recreates the resource fresh, recorded under v4 state.
+   - **Caveat:** any secret you delete from TSS to avoid a name collision is permanently gone; back up first.
+
+3. **Manual state surgery.** Edit `terraform.tfstate` to convert SDKv2 shape to framework shape and bump `schema_version` to `1`. Risky, unsupported, requires understanding both shapes — only suitable for experienced operators with reliable backups.
+
+There is no automatic path from v2.x state to v4 today. If your scenario isn't served by 1–3 above, please file a GitHub issue.
+
 ## Delete Secret by ID
 
 The `tss_secret_deletion` resource allows you to delete secrets by their ID, even if they are not managed by Terraform state.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ The generated password reaches Secret Server through the normal create/update fl
 - Legacy configs that set `itemvalue` on a password field still work, but `flattenSecret` now nulls the value in state, which produces a perpetual plan diff. Migrate those fields to `password_value` + `password_wo_version`.
 - Upgrading from v3.1.x or earlier: existing state files still contain plaintext passwords. The first `terraform apply` or `terraform refresh` after the upgrade will null them; no data loss, just state cleanup.
 
+## Computed fields on `tss_resource_secret.fields`
+
+Each `fields` block has attributes that Secret Server assigns automatically after `terraform apply`. They appear in Terraform state but are not user-settable:
+
+- `itemid` — database ID of this field-value record. Auto-assigned by Secret Server; sequential per newly-created secret.
+- `fieldid` — the template field ID. Stable per template, shared across every secret that uses the template. Not sequential.
+- `slug` — the field's URL slug, assigned by the template.
+- `fielddescription` — the field description, set by the template.
+
+Setting any of these four in your config produces a plan error ("Can't configure a value for `itemid`: its value will be decided automatically based on the result of applying this configuration"). That's the signal that these are server-assigned — leave them out.
+
+One exception: `fileattachmentid` is both `Computed` and `Optional`. It's genuinely user-settable for file-type fields (you can point an existing attachment at this field), and populated automatically for non-file fields.
+
 ## Delete Secret by ID
 
 The `tss_secret_deletion` resource allows you to delete secrets by their ID, even if they are not managed by Terraform state.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ fields {
 
 On plan, Terraform sees the `password_wo_version` change and schedules an update; on apply, the provider reads `password_value` from config and sends it to Secret Server. Any new integer works — only the change is significant.
 
+### Server-side password generation
+
+If you don't want to supply a password value yourself, set `generate = true` on the field. The provider asks Secret Server for a password matching the template's password-requirement policy and uses that value:
+
+```hcl
+resource "tss_resource_secret" "db" {
+  name             = "db-prod"
+  folderid         = "42"
+  siteid           = "1"
+  secrettemplateid = "2"
+
+  fields {
+    fieldname = "Username"
+    itemvalue = "dbadmin"
+  }
+  fields {
+    fieldname           = "Password"
+    generate            = true
+    password_wo_version = 1
+  }
+}
+```
+
+`generate` is mutually exclusive with `password_value` and (for password fields) `itemvalue` — the provider rejects configs that set both. Rotation works the same way as for `password_value`: bump `password_wo_version` to ask for a new generated password on the next apply. Re-applying with the same `password_wo_version` is a no-op (no API call to the generate endpoint, no rotation).
+
+The generated password reaches Secret Server through the normal create/update flow. It never lands in `terraform.tfstate` because `flattenSecret` nulls `itemvalue` for fields the template marks `IsPassword`.
+
 ### Guarantees and caveats
 
 - `terraform.tfstate` contains no plaintext password. Post-apply, `itemvalue` is `null` for any field the template marks `IsPassword`.

--- a/delinea/resource_secret.go
+++ b/delinea/resource_secret.go
@@ -508,24 +508,25 @@ func (r *TSSSecretResource) Schema(ctx context.Context, req resource.SchemaReque
 							Description: "Request server-side password generation from the template's password-requirement policy (closes gh #110). Only honored on fields the template marks as password fields. Mutually exclusive with password_value and itemvalue. Pair with password_wo_version to rotate the generated password.",
 						},
 						"itemid": schema.Int64Attribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Server-assigned database ID of this field-value record. Populated after apply; do not set in config.",
 						},
 						"fieldid": schema.Int64Attribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Secret Server template field ID; stable per template, shared across every secret that uses the template. Populated after apply; do not set in config.",
 						},
 						"fileattachmentid": schema.Int64Attribute{
-							Optional: true,
-							Computed: true,
+							Optional:    true,
+							Computed:    true,
+							Description: "File attachment ID. Only meaningful for file-type fields; genuinely user-settable there as an alternative to uploading a new file.",
 						},
 						"slug": schema.StringAttribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Field's URL slug, assigned by the template. Populated after apply; do not set in config.",
 						},
 						"fielddescription": schema.StringAttribute{
-							Optional: true,
-							Computed: true,
+							Computed:    true,
+							Description: "Field description from the template. Populated after apply; do not set in config.",
 						},
 						"filename": schema.StringAttribute{
 							Optional: true,

--- a/delinea/resource_secret.go
+++ b/delinea/resource_secret.go
@@ -52,6 +52,7 @@ type SecretField struct {
 	ItemValue         types.String `tfsdk:"itemvalue"`
 	PasswordValue     types.String `tfsdk:"password_value"`
 	PasswordWoVersion types.Int64  `tfsdk:"password_wo_version"`
+	Generate          types.Bool   `tfsdk:"generate"`
 	ItemID            types.Int64  `tfsdk:"itemid"`
 	FieldID           types.Int64  `tfsdk:"fieldid"`
 	FileAttachmentID  types.Int64  `tfsdk:"fileattachmentid"`
@@ -500,7 +501,11 @@ func (r *TSSSecretResource) Schema(ctx context.Context, req resource.SchemaReque
 						},
 						"password_wo_version": schema.Int64Attribute{
 							Optional:    true,
-							Description: "Rotation trigger for password_value. Bump this integer to signal Terraform that the password_value has changed and should be re-sent to TSS; any new value is fine, only the change matters.",
+							Description: "Rotation trigger for password_value or generate. Bump this integer to signal Terraform that the password_value has changed and should be re-sent to TSS, or that a new password should be generated when generate=true; any new value is fine, only the change matters.",
+						},
+						"generate": schema.BoolAttribute{
+							Optional:    true,
+							Description: "Request server-side password generation from the template's password-requirement policy (closes gh #110). Only honored on fields the template marks as password fields. Mutually exclusive with password_value and itemvalue. Pair with password_wo_version to rotate the generated password.",
 						},
 						"itemid": schema.Int64Attribute{
 							Optional: true,
@@ -698,9 +703,9 @@ func mergeWriteOnlyFieldValues(plan, config []SecretField) {
 //
 // For each matched field, user-set attributes that the TSS API does not round-trip
 // are copied from the reference into the aligned result: password_wo_version is
-// the rotation trigger for the write-only password_value attribute, so it lives
-// only on the Terraform side and must be preserved from plan (on Create/Update)
-// or prior state (on Read).
+// the rotation trigger for the write-only password_value attribute, and generate
+// is the request-server-side-generation flag — both live only on the Terraform
+// side and must be preserved from plan (on Create/Update) or prior state (on Read).
 func alignFieldsToReference(fields []SecretField, reference []SecretField) []SecretField {
 	if reference == nil {
 		return fields
@@ -713,6 +718,7 @@ func alignFieldsToReference(fields []SecretField, reference []SecretField) []Sec
 	for _, r := range reference {
 		if f, ok := byName[strings.ToLower(r.FieldName.ValueString())]; ok {
 			f.PasswordWoVersion = r.PasswordWoVersion
+			f.Generate = r.Generate
 			aligned = append(aligned, f)
 		}
 	}
@@ -754,11 +760,30 @@ func (r *TSSSecretResource) getSecretData(ctx context.Context, state *SecretReso
 			}
 		}
 
+		hasGenerate := !field.Generate.IsNull() && field.Generate.ValueBool()
 		hasPasswordValue := !field.PasswordValue.IsNull() && field.PasswordValue.ValueString() != ""
 		hasItemValue := !field.ItemValue.IsNull() && field.ItemValue.ValueString() != ""
 
+		if hasGenerate {
+			if !templateField.IsPassword {
+				return nil, fmt.Errorf("field %q has generate=true but is not a password field on template %q; only fields with isPassword=true support template-policy generation", fieldName, template.Name)
+			}
+			if hasPasswordValue {
+				return nil, fmt.Errorf("field %q has both generate=true and password_value set; they are mutually exclusive", fieldName)
+			}
+			if hasItemValue {
+				return nil, fmt.Errorf("field %q has both generate=true and itemvalue set; they are mutually exclusive on a password field", fieldName)
+			}
+		}
+
 		var itemValue string
 		switch {
+		case hasGenerate:
+			pw, err := client.GeneratePassword(templateField.FieldSlugName, template)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate password for field %q from template policy: %w", fieldName, err)
+			}
+			itemValue = pw
 		case hasPasswordValue:
 			itemValue = field.PasswordValue.ValueString()
 		case hasItemValue:

--- a/delinea/resource_secret.go
+++ b/delinea/resource_secret.go
@@ -371,6 +371,7 @@ func (r *TSSSecretResource) Delete(ctx context.Context, req resource.DeleteReque
 // Schema defines the schema for the resource
 func (r *TSSSecretResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Required:    true,

--- a/delinea/resource_secret_acceptance_test.go
+++ b/delinea/resource_secret_acceptance_test.go
@@ -122,6 +122,7 @@ type fieldSpec struct {
 	ItemValue         string // if non-empty, emit itemvalue
 	PasswordValue     string // if non-empty, emit password_value (write-only)
 	PasswordWoVersion int    // if non-zero, emit password_wo_version
+	Generate          bool   // if true, emit generate=true
 }
 
 func testAccSecretConfig(name string, fields ...fieldSpec) string {
@@ -136,6 +137,9 @@ func testAccSecretConfig(name string, fields ...fieldSpec) string {
 		}
 		if f.PasswordWoVersion != 0 {
 			fieldBlocks += fmt.Sprintf("    password_wo_version = %d\n", f.PasswordWoVersion)
+		}
+		if f.Generate {
+			fieldBlocks += "    generate = true\n"
 		}
 		fieldBlocks += "  }"
 	}
@@ -331,6 +335,86 @@ func TestAccTSSSecret_PasswordValueChangeWithoutVersionBumpIsNoOp(t *testing.T) 
 			{Config: step1},
 			{
 				Config:             step2,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// gh #110: Create with generate=true asks TSS for a password matching the
+// template's password-requirement policy and uses it as the field's
+// itemvalue. State has no plaintext password (same WriteOnly null behavior
+// as PasswordValue). The generated password should never appear in state.
+func TestAccTSSSecret_GeneratePasswordFromTemplatePolicy(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-generate")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretConfig(name,
+					fieldSpec{Name: "Username", ItemValue: "testuser"},
+					fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.generate", "true"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+// gh #110: Bumping password_wo_version while generate=true triggers an
+// Update; the provider re-calls the generate endpoint and TSS stores the
+// new generated password. State retains generate=true and the new version.
+func TestAccTSSSecret_GeneratePasswordRotation(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-gen-rotate")
+	step1 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+	)
+	step2 := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 2},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: step1,
+				Check:  resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "1"),
+			},
+			{
+				Config: step2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.password_wo_version", "2"),
+					resource.TestCheckResourceAttr("tss_resource_secret.test", "fields.1.itemvalue", ""),
+				),
+			},
+		},
+	})
+}
+
+// gh #110: re-applying a generate=true config without bumping
+// password_wo_version must be a no-op (no API call to generate-password,
+// no diff). Same property as the password_value case.
+func TestAccTSSSecret_GenerateNoBumpIsNoOp(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-gen-noop")
+	config := testAccSecretConfig(name,
+		fieldSpec{Name: "Username", ItemValue: "testuser"},
+		fieldSpec{Name: "Password", Generate: true, PasswordWoVersion: 1},
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/delinea/resource_secret_test.go
+++ b/delinea/resource_secret_test.go
@@ -257,6 +257,39 @@ func TestAlignFieldsToReference_NullPasswordWoVersionInReferenceStaysNull(t *tes
 	}
 }
 
+func TestAlignFieldsToReference_PreservesGenerateFromReference(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolValue(true)},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d fields, want 1", len(got))
+	}
+	if !got[0].Generate.ValueBool() {
+		t.Fatalf("got generate=%v, want true", got[0].Generate)
+	}
+}
+
+func TestAlignFieldsToReference_NullGenerateInReferenceStaysNull(t *testing.T) {
+	apiResponse := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+	userConfig := []SecretField{
+		{FieldName: types.StringValue("Password"), Generate: types.BoolNull()},
+	}
+
+	got := alignFieldsToReference(apiResponse, userConfig)
+
+	if !got[0].Generate.IsNull() {
+		t.Fatalf("got generate=%v, want null", got[0].Generate)
+	}
+}
+
 func TestFlattenSecret_NullsItemValueForPasswordFields(t *testing.T) {
 	secret := &server.Secret{
 		ID:   42,

--- a/delinea/resource_secret_test.go
+++ b/delinea/resource_secret_test.go
@@ -1,11 +1,14 @@
 package delinea
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/DelineaXPM/tss-sdk-go/v2/server"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -424,4 +427,54 @@ func Example_alignFieldsToReference_refresh() {
 	// Output:
 	// Username
 	// Password
+}
+
+func fieldsBlockAttributes(t *testing.T) map[string]schema.Attribute {
+	t.Helper()
+	r := &TSSSecretResource{}
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Schema() returned diagnostics: %v", resp.Diagnostics)
+	}
+	block, ok := resp.Schema.Blocks["fields"].(schema.ListNestedBlock)
+	if !ok {
+		t.Fatalf("fields block missing or wrong type: %T", resp.Schema.Blocks["fields"])
+	}
+	return block.NestedObject.Attributes
+}
+
+// PBI 718755: these four attributes are server-assigned. Declaring them
+// Computed-only (no Optional) is what makes Terraform reject configs that try
+// to set them, which is the diagnostic the customer needed.
+func TestSchema_ServerAssignedFieldsAreComputedOnly(t *testing.T) {
+	attrs := fieldsBlockAttributes(t)
+	for _, name := range []string{"itemid", "fieldid", "slug", "fielddescription"} {
+		attr, ok := attrs[name]
+		if !ok {
+			t.Fatalf("%s: attribute missing from fields block", name)
+		}
+		if !attr.IsComputed() {
+			t.Errorf("%s: IsComputed() = false, want true", name)
+		}
+		if attr.IsOptional() {
+			t.Errorf("%s: IsOptional() = true, want false (setting in config must produce a plan-time error)", name)
+		}
+	}
+}
+
+// fileattachmentid is the documented exception: it is genuinely user-settable
+// on file-type fields, so it must stay Optional+Computed.
+func TestSchema_FileAttachmentIDIsOptionalAndComputed(t *testing.T) {
+	attrs := fieldsBlockAttributes(t)
+	attr, ok := attrs["fileattachmentid"]
+	if !ok {
+		t.Fatal("fileattachmentid: attribute missing from fields block")
+	}
+	if !attr.IsOptional() {
+		t.Error("fileattachmentid: IsOptional() = false, want true")
+	}
+	if !attr.IsComputed() {
+		t.Error("fileattachmentid: IsComputed() = false, want true")
+	}
 }

--- a/delinea/resource_secret_upgrade.go
+++ b/delinea/resource_secret_upgrade.go
@@ -1,0 +1,207 @@
+package delinea
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// State versioning history for tss_resource_secret:
+//
+//   - Schema version 0: provider versions v3.x. Same struct shape as today
+//     except no password_value, no password_wo_version, no generate;
+//     itemvalue not Sensitive; itemid/fieldid/slug/fielddescription
+//     declared Optional+Computed (rather than Computed-only).
+//
+//   - Schema version 1: provider version v4.0.0. Adds password_value
+//     (WriteOnly), password_wo_version (Int64), and generate (Bool) to
+//     the fields block; flips itemvalue to Sensitive; locks
+//     itemid/fieldid/slug/fielddescription to Computed-only.
+//
+// The version 0 -> 1 upgrade is purely additive on the state side: every
+// version-0 attribute exists in version 1 with the same underlying type,
+// and the new attributes default to null. We read the prior state with
+// the version-0 schema, copy values across into the v4 struct, and let
+// the new attributes stay null.
+//
+// Provider v2.x state (terraform-plugin-sdk v2 era) is not handled here.
+// Its on-disk structure is incompatible enough that an in-place upgrade
+// would be a separate, larger piece of work. v2.x users should upgrade
+// to v3.x first via the recommended manual path documented in the
+// release notes.
+
+func (r *TSSSecretResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: priorSchemaV0(),
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var prior secretResourceStateV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgraded := SecretResourceState{
+					ID:                               prior.ID,
+					Name:                             prior.Name,
+					FolderID:                         prior.FolderID,
+					SiteID:                           prior.SiteID,
+					SecretTemplateID:                 prior.SecretTemplateID,
+					SshKeyArgs:                       prior.SshKeyArgs,
+					Active:                           prior.Active,
+					SecretPolicyID:                   prior.SecretPolicyID,
+					PasswordTypeWebScriptID:          prior.PasswordTypeWebScriptID,
+					LauncherConnectAsSecretID:        prior.LauncherConnectAsSecretID,
+					CheckOutIntervalMinutes:          prior.CheckOutIntervalMinutes,
+					CheckedOut:                       prior.CheckedOut,
+					CheckOutEnabled:                  prior.CheckOutEnabled,
+					AutoChangeEnabled:                prior.AutoChangeEnabled,
+					CheckOutChangePasswordEnabled:    prior.CheckOutChangePasswordEnabled,
+					DelayIndexing:                    prior.DelayIndexing,
+					EnableInheritPermissions:         prior.EnableInheritPermissions,
+					EnableInheritSecretPolicy:        prior.EnableInheritSecretPolicy,
+					ProxyEnabled:                     prior.ProxyEnabled,
+					RequiresComment:                  prior.RequiresComment,
+					SessionRecordingEnabled:          prior.SessionRecordingEnabled,
+					WebLauncherRequiresIncognitoMode: prior.WebLauncherRequiresIncognitoMode,
+				}
+				upgraded.Fields = upgradeFieldsV0ToV1(prior.Fields)
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, &upgraded)...)
+			},
+		},
+	}
+}
+
+// secretFieldV0 mirrors the v3.x SecretField struct. v4 adds three
+// attributes (password_value, password_wo_version, generate); existing
+// attributes keep the same Go types and tfsdk tags.
+type secretFieldV0 struct {
+	FieldName        types.String `tfsdk:"fieldname"`
+	ItemValue        types.String `tfsdk:"itemvalue"`
+	ItemID           types.Int64  `tfsdk:"itemid"`
+	FieldID          types.Int64  `tfsdk:"fieldid"`
+	FileAttachmentID types.Int64  `tfsdk:"fileattachmentid"`
+	Slug             types.String `tfsdk:"slug"`
+	FieldDescription types.String `tfsdk:"fielddescription"`
+	Filename         types.String `tfsdk:"filename"`
+	IsFile           types.Bool   `tfsdk:"isfile"`
+	IsNotes          types.Bool   `tfsdk:"isnotes"`
+	IsPassword       types.Bool   `tfsdk:"ispassword"`
+	IsList           types.Bool   `tfsdk:"islist"`
+	ListType         types.String `tfsdk:"listtype"`
+}
+
+type secretResourceStateV0 struct {
+	ID                               types.Int64     `tfsdk:"id"`
+	Name                             types.String    `tfsdk:"name"`
+	FolderID                         types.String    `tfsdk:"folderid"`
+	SiteID                           types.String    `tfsdk:"siteid"`
+	SecretTemplateID                 types.String    `tfsdk:"secrettemplateid"`
+	Fields                           []secretFieldV0 `tfsdk:"fields"`
+	SshKeyArgs                       *SshKeyArgs     `tfsdk:"sshkeyargs"`
+	Active                           types.Bool      `tfsdk:"active"`
+	SecretPolicyID                   types.Int64     `tfsdk:"secretpolicyid"`
+	PasswordTypeWebScriptID          types.Int64     `tfsdk:"passwordtypewebscriptid"`
+	LauncherConnectAsSecretID        types.Int64     `tfsdk:"launcherconnectassecretid"`
+	CheckOutIntervalMinutes          types.Int64     `tfsdk:"checkoutintervalminutes"`
+	CheckedOut                       types.Bool      `tfsdk:"checkedout"`
+	CheckOutEnabled                  types.Bool      `tfsdk:"checkoutenabled"`
+	AutoChangeEnabled                types.Bool      `tfsdk:"autochangenabled"`
+	CheckOutChangePasswordEnabled    types.Bool      `tfsdk:"checkoutchangepasswordenabled"`
+	DelayIndexing                    types.Bool      `tfsdk:"delayindexing"`
+	EnableInheritPermissions         types.Bool      `tfsdk:"enableinheritpermissions"`
+	EnableInheritSecretPolicy        types.Bool      `tfsdk:"enableinheritsecretpolicy"`
+	ProxyEnabled                     types.Bool      `tfsdk:"proxyenabled"`
+	RequiresComment                  types.Bool      `tfsdk:"requirescomment"`
+	SessionRecordingEnabled          types.Bool      `tfsdk:"sessionrecordingenabled"`
+	WebLauncherRequiresIncognitoMode types.Bool      `tfsdk:"weblauncherrequiresincognitomode"`
+}
+
+// upgradeFieldsV0ToV1 copies every v0 field into a fresh v1 SecretField.
+// password_value, password_wo_version, and generate stay at their zero
+// values (null); they were not present in v0 state.
+func upgradeFieldsV0ToV1(fields []secretFieldV0) []SecretField {
+	if fields == nil {
+		return nil
+	}
+	out := make([]SecretField, len(fields))
+	for i, f := range fields {
+		out[i] = SecretField{
+			FieldName:        f.FieldName,
+			ItemValue:        f.ItemValue,
+			ItemID:           f.ItemID,
+			FieldID:          f.FieldID,
+			FileAttachmentID: f.FileAttachmentID,
+			Slug:             f.Slug,
+			FieldDescription: f.FieldDescription,
+			Filename:         f.Filename,
+			IsFile:           f.IsFile,
+			IsNotes:          f.IsNotes,
+			IsPassword:       f.IsPassword,
+			IsList:           f.IsList,
+			ListType:         f.ListType,
+		}
+	}
+	return out
+}
+
+// priorSchemaV0 mirrors the v3.x schema for tss_resource_secret. It
+// describes only what the framework needs to read v3.x state — no plan
+// modifiers, validators, or markdown descriptions.
+func priorSchemaV0() *schema.Schema {
+	return &schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":                             schema.StringAttribute{Required: true},
+			"folderid":                         schema.StringAttribute{Required: true},
+			"siteid":                           schema.StringAttribute{Required: true},
+			"secrettemplateid":                 schema.StringAttribute{Required: true},
+			"id":                               schema.Int64Attribute{Computed: true},
+			"active":                           schema.BoolAttribute{Optional: true, Computed: true},
+			"secretpolicyid":                   schema.Int64Attribute{Optional: true, Computed: true},
+			"passwordtypewebscriptid":          schema.Int64Attribute{Optional: true, Computed: true},
+			"launcherconnectassecretid":        schema.Int64Attribute{Optional: true, Computed: true},
+			"checkoutintervalminutes":          schema.Int64Attribute{Optional: true, Computed: true},
+			"checkedout":                       schema.BoolAttribute{Optional: true, Computed: true},
+			"checkoutenabled":                  schema.BoolAttribute{Optional: true, Computed: true},
+			"autochangenabled":                 schema.BoolAttribute{Optional: true, Computed: true},
+			"checkoutchangepasswordenabled":    schema.BoolAttribute{Optional: true, Computed: true},
+			"delayindexing":                    schema.BoolAttribute{Optional: true, Computed: true},
+			"enableinheritpermissions":         schema.BoolAttribute{Optional: true, Computed: true},
+			"enableinheritsecretpolicy":        schema.BoolAttribute{Optional: true, Computed: true},
+			"proxyenabled":                     schema.BoolAttribute{Optional: true, Computed: true},
+			"requirescomment":                  schema.BoolAttribute{Optional: true, Computed: true},
+			"sessionrecordingenabled":          schema.BoolAttribute{Optional: true, Computed: true},
+			"weblauncherrequiresincognitomode": schema.BoolAttribute{Optional: true, Computed: true},
+		},
+		Blocks: map[string]schema.Block{
+			"fields": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"fieldname":        schema.StringAttribute{Required: true},
+						"itemvalue":        schema.StringAttribute{Optional: true, Computed: true},
+						"itemid":           schema.Int64Attribute{Optional: true, Computed: true},
+						"fieldid":          schema.Int64Attribute{Optional: true, Computed: true},
+						"fileattachmentid": schema.Int64Attribute{Optional: true, Computed: true},
+						"slug":             schema.StringAttribute{Optional: true, Computed: true},
+						"fielddescription": schema.StringAttribute{Optional: true, Computed: true},
+						"filename":         schema.StringAttribute{Optional: true, Computed: true},
+						"isfile":           schema.BoolAttribute{Optional: true, Computed: true},
+						"isnotes":          schema.BoolAttribute{Optional: true, Computed: true},
+						"ispassword":       schema.BoolAttribute{Optional: true, Computed: true},
+						"islist":           schema.BoolAttribute{Optional: true, Computed: true},
+						"listtype":         schema.StringAttribute{Optional: true, Computed: true},
+					},
+				},
+			},
+			"sshkeyargs": schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"generatepassphrase": schema.BoolAttribute{Required: true},
+					"generatesshkeys":    schema.BoolAttribute{Required: true},
+				},
+			},
+		},
+	}
+}

--- a/delinea/resource_secret_upgrade_test.go
+++ b/delinea/resource_secret_upgrade_test.go
@@ -1,0 +1,154 @@
+package delinea
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func priorSchemaV0FieldsAttrs(t *testing.T) map[string]schema.Attribute {
+	t.Helper()
+	s := priorSchemaV0()
+	block, ok := s.Blocks["fields"].(schema.ListNestedBlock)
+	if !ok {
+		t.Fatalf("priorSchemaV0 fields block missing or wrong type: %T", s.Blocks["fields"])
+	}
+	return block.NestedObject.Attributes
+}
+
+func TestUpgradeFieldsV0ToV1_NilReturnsNil(t *testing.T) {
+	got := upgradeFieldsV0ToV1(nil)
+	if got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+func TestUpgradeFieldsV0ToV1_EmptyReturnsEmpty(t *testing.T) {
+	got := upgradeFieldsV0ToV1([]secretFieldV0{})
+	if len(got) != 0 {
+		t.Fatalf("got %d fields, want 0", len(got))
+	}
+}
+
+func TestUpgradeFieldsV0ToV1_CopiesEveryV0Attribute(t *testing.T) {
+	prior := []secretFieldV0{
+		{
+			FieldName:        types.StringValue("Password"),
+			ItemValue:        types.StringValue("legacy-plaintext"),
+			ItemID:           types.Int64Value(101),
+			FieldID:          types.Int64Value(7),
+			FileAttachmentID: types.Int64Value(0),
+			Slug:             types.StringValue("password"),
+			FieldDescription: types.StringValue("the password used to access information"),
+			Filename:         types.StringNull(),
+			IsFile:           types.BoolValue(false),
+			IsNotes:          types.BoolValue(false),
+			IsPassword:       types.BoolValue(true),
+			IsList:           types.BoolValue(false),
+			ListType:         types.StringValue("None"),
+		},
+	}
+
+	got := upgradeFieldsV0ToV1(prior)
+	if len(got) != 1 {
+		t.Fatalf("got %d fields, want 1", len(got))
+	}
+
+	want := SecretField{
+		FieldName:        types.StringValue("Password"),
+		ItemValue:        types.StringValue("legacy-plaintext"),
+		ItemID:           types.Int64Value(101),
+		FieldID:          types.Int64Value(7),
+		FileAttachmentID: types.Int64Value(0),
+		Slug:             types.StringValue("password"),
+		FieldDescription: types.StringValue("the password used to access information"),
+		Filename:         types.StringNull(),
+		IsFile:           types.BoolValue(false),
+		IsNotes:          types.BoolValue(false),
+		IsPassword:       types.BoolValue(true),
+		IsList:           types.BoolValue(false),
+		ListType:         types.StringValue("None"),
+		// New v1 attributes default to null/zero — that is the contract.
+	}
+	if !reflect.DeepEqual(got[0], want) {
+		t.Fatalf("got %+v, want %+v", got[0], want)
+	}
+}
+
+// The new v1 attributes (password_value, password_wo_version, generate)
+// must be null on upgraded rows so a refresh against v4 doesn't see
+// state-vs-config drift on rows that the user never set them on.
+func TestUpgradeFieldsV0ToV1_NewAttributesAreNull(t *testing.T) {
+	prior := []secretFieldV0{
+		{FieldName: types.StringValue("Password"), ItemValue: types.StringValue("legacy")},
+	}
+
+	got := upgradeFieldsV0ToV1(prior)
+
+	if !got[0].PasswordValue.IsNull() {
+		t.Errorf("PasswordValue: got %v, want null", got[0].PasswordValue)
+	}
+	if !got[0].PasswordWoVersion.IsNull() {
+		t.Errorf("PasswordWoVersion: got %v, want null", got[0].PasswordWoVersion)
+	}
+	if !got[0].Generate.IsNull() {
+		t.Errorf("Generate: got %v, want null", got[0].Generate)
+	}
+}
+
+func TestUpgradeFieldsV0ToV1_OrderPreserved(t *testing.T) {
+	prior := []secretFieldV0{
+		{FieldName: types.StringValue("Username")},
+		{FieldName: types.StringValue("Password")},
+		{FieldName: types.StringValue("Notes")},
+	}
+	got := upgradeFieldsV0ToV1(prior)
+	want := []string{"Username", "Password", "Notes"}
+	for i, name := range want {
+		if got[i].FieldName.ValueString() != name {
+			t.Fatalf("position %d: got %q, want %q", i, got[i].FieldName.ValueString(), name)
+		}
+	}
+}
+
+func TestPriorSchemaV0_HasFieldsBlock(t *testing.T) {
+	s := priorSchemaV0()
+	if _, ok := s.Blocks["fields"]; !ok {
+		t.Fatal("priorSchemaV0 must declare a fields block; got none")
+	}
+}
+
+// PBI 718755 reverted: in v0/v3, itemid/fieldid/slug/fielddescription
+// were Optional+Computed (not yet locked down). The upgrader must
+// declare them that way, otherwise framework state parsing rejects
+// any v3 state file that has values for those attributes.
+func TestPriorSchemaV0_ServerAssignedFieldsAreOptionalAndComputed(t *testing.T) {
+	attrs := priorSchemaV0FieldsAttrs(t)
+	for _, name := range []string{"itemid", "fieldid", "slug", "fielddescription"} {
+		attr, ok := attrs[name]
+		if !ok {
+			t.Fatalf("v0 fields.%s: attribute missing", name)
+			continue
+		}
+		if !attr.IsOptional() {
+			t.Errorf("v0 %s: IsOptional() = false, want true", name)
+		}
+		if !attr.IsComputed() {
+			t.Errorf("v0 %s: IsComputed() = false, want true", name)
+		}
+	}
+}
+
+// The v1 schema added password_value, password_wo_version, and generate.
+// The v0 prior schema must not declare them, otherwise the framework
+// will reject v3 state that lacks those keys.
+func TestPriorSchemaV0_DoesNotDeclareV1OnlyAttributes(t *testing.T) {
+	attrs := priorSchemaV0FieldsAttrs(t)
+	for _, name := range []string{"password_value", "password_wo_version", "generate"} {
+		if _, ok := attrs[name]; ok {
+			t.Errorf("v0 fields.%s present; v0 must not declare attributes added in v1", name)
+		}
+	}
+}

--- a/docs/resources/resource_secret.md
+++ b/docs/resources/resource_secret.md
@@ -56,9 +56,7 @@ Required:
 
 Optional:
 
-- `fielddescription` (String)
-- `fieldid` (Number)
-- `fileattachmentid` (Number)
+- `fileattachmentid` (Number) File attachment ID. Only meaningful for file-type fields; genuinely user-settable there as an alternative to uploading a new file.
 - `filename` (String)
 - `isfile` (Boolean)
 - `islist` (Boolean)
@@ -69,7 +67,13 @@ Optional:
 - `password_value` (String, Sensitive, Write-only) Password value for password fields. Never stored in Terraform state. Requires Terraform 1.11+. Pair with `password_wo_version` to trigger rotation.
 - `password_wo_version` (Number) Rotation trigger for `password_value` or `generate`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server, or to ask for a new generated password when `generate=true`, on the next apply.
 - `generate` (Boolean) Request server-side password generation from the template's password-requirement policy. Only honored on fields the template marks as password fields. Mutually exclusive with `password_value` and `itemvalue`. Pair with `password_wo_version` to rotate. Closes [GitHub issue #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110).
-- `slug` (String)
+
+Read-Only:
+
+- `fielddescription` (String) Field description from the template. Populated after apply; do not set in config.
+- `fieldid` (Number) Secret Server template field ID; stable per template, shared across every secret that uses the template. Populated after apply; do not set in config.
+- `itemid` (Number) Server-assigned database ID of this field-value record. Populated after apply; do not set in config.
+- `slug` (String) Field's URL slug, assigned by the template. Populated after apply; do not set in config.
 
 
 <a id="nestedblock--sshkeyargs"></a>
@@ -141,3 +145,16 @@ resource "tss_resource_secret" "example" {
 ```
 
 To rotate the password, change `password_value` and bump `password_wo_version` (any new integer) in the same apply. The provider detects the version change and pushes the new value to Secret Server. See the README's "Password handling" section for the full guarantees and the upgrade path from pre-v4.0.0 state files.
+
+### Computed Fields
+
+Each `fields` block has attributes that Secret Server assigns automatically after `terraform apply`. They appear in Terraform state but are not user-settable:
+
+- `itemid` — database ID of this field-value record. Auto-assigned by Secret Server; sequential per newly-created secret.
+- `fieldid` — the template field ID. Stable per template, shared across every secret that uses the template. Not sequential.
+- `slug` — the field's URL slug, assigned by the template.
+- `fielddescription` — the field description, set by the template.
+
+Setting any of these four in your config produces a plan error ("Can't configure a value for `itemid`: its value will be decided automatically based on the result of applying this configuration"). That's the signal that these are server-assigned — leave them out.
+
+One exception: `fileattachmentid` is both `Computed` and `Optional`. It's genuinely user-settable for file-type fields (you can point an existing attachment at this field), and populated automatically for non-file fields.

--- a/docs/resources/resource_secret.md
+++ b/docs/resources/resource_secret.md
@@ -67,7 +67,8 @@ Optional:
 - `itemvalue` (String, Sensitive) The value of the field. For password fields, prefer `password_value` — `itemvalue` is nulled in state on read, which produces a perpetual diff if used for a password.
 - `listtype` (String)
 - `password_value` (String, Sensitive, Write-only) Password value for password fields. Never stored in Terraform state. Requires Terraform 1.11+. Pair with `password_wo_version` to trigger rotation.
-- `password_wo_version` (Number) Rotation trigger for `password_value`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server on the next apply.
+- `password_wo_version` (Number) Rotation trigger for `password_value` or `generate`. Bump this integer to signal Terraform to re-send `password_value` to Secret Server, or to ask for a new generated password when `generate=true`, on the next apply.
+- `generate` (Boolean) Request server-side password generation from the template's password-requirement policy. Only honored on fields the template marks as password fields. Mutually exclusive with `password_value` and `itemvalue`. Pair with `password_wo_version` to rotate. Closes [GitHub issue #110](https://github.com/DelineaXPM/terraform-provider-tss/issues/110).
 - `slug` (String)
 
 


### PR DESCRIPTION
[Task 726497](https://dev.azure.com/thycotic/Delinea.Work/_workitems/edit/726497)

> ⚠ **Stacked on #128.** This PR is based on `dbinger-pbi-718755` rather than `dev/v4.0.0`. **Do not merge** until #128 (and #124–#127 before it) have merged and this PR's base has flipped to `dev/v4.0.0`. Held in draft for that reason.

Closes [gh #106](https://github.com/DelineaXPM/terraform-provider-tss/issues/106) for v3.x source state. Without this upgrader, v4.0.0 would reproduce the same "Unable to Read Previously Saved State for UpgradeResourceState" failure that the issue reporter hit going v2.0.x → v3.0.0, only one version forward — so even ignoring the GitHub issue, a v3 → v4 state upgrader is required for v4.0.0 to be releasable.

## What this PR does

`tss_resource_secret`'s schema is now **versioned** (`Version: 1`). The resource implements `ResourceWithUpgradeState` and registers a `0 → 1` upgrader that:

- Reads prior state with a v3-shaped schema (`priorSchemaV0`) — same attributes and types as v3.x, with `itemid` / `fieldid` / `slug` / `fielddescription` declared `Optional+Computed` (pre-PBI 718755 lockdown), and without the v4-only `password_value`, `password_wo_version`, `generate` attributes.
- Copies every v0 attribute across into a v4 `SecretResourceState` / `SecretField` via `upgradeFieldsV0ToV1`.
- Leaves the new v4 attributes at their null/zero defaults.

The v0 → v1 transformation is essentially additive on the state side: every v0 attribute exists in v1 with the same underlying type, so values transfer cleanly; the new attributes default to null because they weren't present in v0 state.

## What this PR does **not** do

**v2.x → v4 is intentionally out of scope.** v2.x used `terraform-plugin-sdk/v2`; its on-disk state shape is fundamentally different from `terraform-plugin-framework`'s. A v2 → v4 upgrader would have to parse SDK-format state and translate it — substantial separate work. Users still on v2.x should upgrade to v3.x first via the path documented at v3.0.0's release time (or recreate state for that resource), then to v4.0.0.

This is documented in `delinea/resource_secret_upgrade.go`'s package comment.

## Tests

Unit tests covering the field-copy contract and the v3-shaped prior schema:

- `TestUpgradeFieldsV0ToV1_NilReturnsNil`, `_EmptyReturnsEmpty`, `_CopiesEveryV0Attribute`, `_NewAttributesAreNull`, `_OrderPreserved`
- `TestPriorSchemaV0_HasFieldsBlock`, `_ServerAssignedFieldsAreOptionalAndComputed`, `_DoesNotDeclareV1OnlyAttributes`

End-to-end test of the upgrader against a saved v3.x state file is deferred to Task 8 (QA pass) — the framework's upgrader path is exercised at `terraform plan` time when state's recorded version is less than the resource's current version.

## QA

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` clean (unit tests; new upgrader-test suite passes).
- [ ] Manual: take a `terraform.tfstate` written by v3.1.x against `tss_resource_secret`, swap the provider binary to v4.0.0, run `terraform plan` — expect a clean plan (no resource-replacement, no "Unable to Read Previously Saved State"). Task 8 timing.
- [ ] Manual (optional): `terraform plan` against v2.x state expects an error mentioning the framework conversion limitation; verifying the message is reasonable. Task 8.
- [ ] CI workflow runs and passes on this PR (Snyk caveat from #124 still applies).
