### PR TITLE
feat: enable provider debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"os"
 
@@ -10,6 +11,11 @@ import (
 )
 
 func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	if len(os.Args) >= 2 {
 		action := os.Args[1]
 		stateFile := os.Args[2]
@@ -39,5 +45,6 @@ func main() {
 
 	providerserver.Serve(context.Background(), delinea.New, providerserver.ServeOpts{
 		Address: "registry.terraform.io/DelineaXPM/tss",
+		Debug:   debug,
 	})
 }


### PR DESCRIPTION
---
Enable Provider Debugging
Add debugging functionality
---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] You have read the contributing guide
- [ ] Tests for the changes have been added
- [X] The documentation has been reviewed and updated as needed

## What is the current behavior?

The Terraform provider always starts in its default mode and does not provide a way to enable Terraform Plugin Framework debugging support when running the provider locally. This makes it more difficult to troubleshoot provider behavior using tools such as Delve during development.

Issue Number: _N/A_

## What is the new behavior?

- Adds a `--debug` command-line flag to the provider executable.
- Enables Terraform Plugin Framework debugging support when the flag is supplied.
- Passes the debug setting to `providerserver.Serve()` through the `Debug` option.
- Maintains the existing provider startup behavior when the flag is not specified.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

**If yes, please describe...**

N/A

## Other relevant information

This change is intended to improve the local development and troubleshooting experience for provider maintainers. The debug functionality is opt-in and does not affect existing workflows unless the `--debug` flag is explicitly provided.